### PR TITLE
Add explicit database modes to dashboard serve

### DIFF
--- a/src/cli/dashboard.py
+++ b/src/cli/dashboard.py
@@ -46,17 +46,25 @@ def dashboard():
     pass
 
 
-def _ensure_db_env(name: str, env: dict) -> dict:
+def _ensure_db_env(name: str, env: dict, *, assume_polis: bool = False) -> dict:
     """Auto-discover DB ARNs from CloudFormation and add to env dict."""
-    if env.get("DB_RESOURCE_ARN") and env.get("DB_SECRET_ARN"):
+    if not assume_polis and env.get("DB_RESOURCE_ARN") and env.get("DB_SECRET_ARN"):
         return env
-
-    import boto3
 
     safe_name = name.replace(".", "-")
     stack_name = f"cogent-{safe_name}-brain"
     try:
-        cf = boto3.client("cloudformation", region_name="us-east-1")
+        if assume_polis:
+            from polis.aws import get_polis_session, set_org_profile
+
+            set_org_profile()
+            session, _ = get_polis_session()
+            cf = session.client("cloudformation", region_name="us-east-1")
+        else:
+            import boto3
+
+            session = None
+            cf = boto3.client("cloudformation", region_name="us-east-1")
         resp = cf.describe_stacks(StackName=stack_name)
         outputs = {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])}
         if "ClusterArn" in outputs:
@@ -72,6 +80,14 @@ def _ensure_db_env(name: str, env: dict) -> dict:
                         env.setdefault("DB_SECRET_ARN", r["PhysicalResourceId"])
                         break
         env.setdefault("DB_NAME", "cogent")
+        if assume_polis and session is not None:
+            creds = session.get_credentials().get_frozen_credentials()
+            env["AWS_ACCESS_KEY_ID"] = creds.access_key
+            env["AWS_SECRET_ACCESS_KEY"] = creds.secret_key
+            if creds.token:
+                env["AWS_SESSION_TOKEN"] = creds.token
+            env.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+            env.setdefault("AWS_REGION", "us-east-1")
     except Exception as e:
         click.echo(f"Warning: could not auto-discover DB credentials: {e}")
     return env
@@ -81,15 +97,35 @@ def _ensure_db_env(name: str, env: dict) -> dict:
 @click.option("--port", default=None, type=int, help="Backend port (default: derived from checkout path)")
 @click.option("--frontend-port", default=None, type=int, help="Frontend port (default: derived from checkout path)")
 @click.option("--no-browser", is_flag=True, help="Don't open browser")
+@click.option(
+    "--db",
+    "db_mode",
+    type=click.Choice(["auto", "local", "prod"]),
+    default="auto",
+    show_default=True,
+    help="DB source: ambient AWS/env (`auto`), local JSON repo (`local`), or polis-assumed live DB (`prod`).",
+)
 @click.option("--local", is_flag=True, help="Use local DB (USE_LOCAL_DB=1)")
 @click.pass_context
-def serve(ctx: click.Context, port: int | None, frontend_port: int | None, no_browser: bool, local: bool):
+def serve(
+    ctx: click.Context,
+    port: int | None,
+    frontend_port: int | None,
+    no_browser: bool,
+    db_mode: str,
+    local: bool,
+):
     """Start the dashboard dev server."""
     from cli import get_cogent_name
 
     default_be, default_fe = _checkout_ports()
     port = port or default_be
     frontend_port = frontend_port or default_fe
+
+    if local:
+        if db_mode != "auto":
+            raise click.UsageError("Use either --local or --db, not both.")
+        db_mode = "local"
 
     name = get_cogent_name(ctx)
     env = {
@@ -100,9 +136,10 @@ def serve(ctx: click.Context, port: int | None, frontend_port: int | None, no_br
         "DASHBOARD_FE_PORT": str(frontend_port),
     }
 
-    if local:
+    if db_mode == "local":
         env["USE_LOCAL_DB"] = "1"
-    env = _ensure_db_env(name, env)
+    else:
+        env = _ensure_db_env(name, env, assume_polis=(db_mode == "prod"))
 
     # Start FastAPI backend
     backend = subprocess.Popen(

--- a/tests/dashboard/test_cli.py
+++ b/tests/dashboard/test_cli.py
@@ -32,3 +32,84 @@ def test_keys_shows_key(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(dashboard, ["keys"], obj={"cogent_id": "test-cogent"})
     assert "my-secret-key" in result.output
+
+
+class _DummyProc:
+    def __init__(self, args, env=None, cwd=None):
+        self.args = args
+        self.env = env or {}
+        self.cwd = cwd
+
+    def terminate(self):
+        return None
+
+    def wait(self):
+        return 0
+
+
+def test_serve_db_prod_uses_polis_lookup(tmp_path, monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_ensure(name: str, env: dict, *, assume_polis: bool = False):
+        calls["name"] = name
+        calls["assume_polis"] = assume_polis
+        env["DB_NAME"] = "cogent"
+        return env
+
+    procs: list[_DummyProc] = []
+
+    def fake_popen(args, env=None, cwd=None):
+        proc = _DummyProc(args, env=env, cwd=cwd)
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr("cli.dashboard._ensure_db_env", fake_ensure)
+    monkeypatch.setattr("cli.dashboard._FRONTEND_DIR", tmp_path / "missing")
+    monkeypatch.setattr("cli.dashboard.subprocess.Popen", fake_popen)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dashboard,
+        ["serve", "--db", "prod", "--no-browser"],
+        obj={"cogent_id": "dr.gamma"},
+    )
+
+    assert result.exit_code == 0
+    assert calls == {"name": "dr.gamma", "assume_polis": True}
+    assert len(procs) == 1
+    assert procs[0].env["DASHBOARD_COGENT_NAME"] == "dr.gamma"
+
+
+def test_serve_db_local_sets_use_local_db(tmp_path, monkeypatch):
+    procs: list[_DummyProc] = []
+
+    def fake_popen(args, env=None, cwd=None):
+        proc = _DummyProc(args, env=env, cwd=cwd)
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr("cli.dashboard._FRONTEND_DIR", tmp_path / "missing")
+    monkeypatch.setattr("cli.dashboard.subprocess.Popen", fake_popen)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dashboard,
+        ["serve", "--db", "local", "--no-browser"],
+        obj={"cogent_id": "dr.gamma"},
+    )
+
+    assert result.exit_code == 0
+    assert len(procs) == 1
+    assert procs[0].env["USE_LOCAL_DB"] == "1"
+
+
+def test_serve_rejects_local_and_db_together(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        dashboard,
+        ["serve", "--db", "prod", "--local", "--no-browser"],
+        obj={"cogent_id": "dr.gamma"},
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --local or --db, not both." in result.output


### PR DESCRIPTION
## Problem
`dashboard serve` did not have an explicit way to say which database backend it should use.

In practice, that left three different modes implicit:
- ambient AWS credentials / existing DB env vars
- local JSON state via `USE_LOCAL_DB=1`
- live polis-backed DB access for local dashboard work against prod data

That made local dashboard startup error-prone. Pointing a local dashboard at the live cogent often required ad hoc shell setup, and the CLI did not make the local-vs-prod choice explicit.

## Summary
- add `--db auto|local|prod` to `dashboard serve`
- keep `--local` as a compatibility alias and reject conflicting `--local` plus `--db` usage
- let `--db prod` resolve live DB credentials through the polis-assumed path while leaving `auto` and `local` behavior explicit
- add focused CLI coverage for prod, local, and invalid flag combinations

## Testing
- `uv run --with pytest pytest tests/dashboard/test_cli.py -q`
