### PR TITLE
Fix dashboard docker deploy to target the dashboard ECS service

### DIFF
--- a/src/brain/update_cli.py
+++ b/src/brain/update_cli.py
@@ -390,10 +390,15 @@ def _get_sessions_bucket(session, safe_name: str) -> str:
     return bucket
 
 
+def _is_dashboard_service_name(service_name: str, safe_name: str) -> bool:
+    """Return True when the ECS service name belongs to the dashboard."""
+    return safe_name in service_name and ("DashService" in service_name or "dashboard" in service_name)
+
+
 def _find_dashboard_service(ecs_client, safe_name: str) -> str:
     """Find the dashboard ECS service ARN on cogent-polis cluster."""
     services = ecs_client.list_services(cluster="cogent-polis").get("serviceArns", [])
-    dash_services = [s for s in services if safe_name in s]
+    dash_services = [s for s in services if _is_dashboard_service_name(s.rsplit("/", 1)[-1], safe_name)]
     if not dash_services:
         raise click.ClickException(f"No dashboard service found for {safe_name} on cogent-polis cluster")
     return dash_services[0]

--- a/tests/brain/test_update_cli.py
+++ b/tests/brain/test_update_cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from brain.update_cli import _find_dashboard_service, _is_dashboard_service_name
+
+
+class _FakeEcsClient:
+    def __init__(self, service_arns: list[str]):
+        self.service_arns = service_arns
+
+    def list_services(self, cluster: str) -> dict[str, list[str]]:
+        assert cluster == "cogent-polis"
+        return {"serviceArns": self.service_arns}
+
+
+def test_is_dashboard_service_name_rejects_non_dashboard_services():
+    assert _is_dashboard_service_name("cogent-dr-gamma-brain-DashService09A25EB6-mc4IBPRXHnGZ", "dr-gamma")
+    assert _is_dashboard_service_name("cogent-dr-gamma-dashboard", "dr-gamma")
+    assert not _is_dashboard_service_name("cogent-dr-gamma-discord", "dr-gamma")
+
+
+def test_find_dashboard_service_prefers_dashboard_service_over_discord():
+    ecs_client = _FakeEcsClient(
+        [
+            "arn:aws:ecs:us-east-1:901289084804:service/cogent-polis/cogent-dr-gamma-discord",
+            "arn:aws:ecs:us-east-1:901289084804:service/cogent-polis/cogent-dr-gamma-brain-DashService09A25EB6-mc4IBPRXHnGZ",
+        ]
+    )
+
+    service_arn = _find_dashboard_service(ecs_client, "dr-gamma")
+
+    assert service_arn.endswith("cogent-dr-gamma-brain-DashService09A25EB6-mc4IBPRXHnGZ")
+
+
+def test_find_dashboard_service_raises_when_dashboard_service_missing():
+    ecs_client = _FakeEcsClient(
+        ["arn:aws:ecs:us-east-1:901289084804:service/cogent-polis/cogent-dr-gamma-discord"]
+    )
+
+    with pytest.raises(Exception, match="No dashboard service found"):
+        _find_dashboard_service(ecs_client, "dr-gamma")


### PR DESCRIPTION
## Problem
`dashboard deploy --docker` selected the first ECS service whose name contained the cogent name.

That was too broad for cogents that have multiple sibling ECS services. In particular, it could pick the Discord bridge instead of the dashboard service, which means the deploy path would restart or update the wrong service while leaving the dashboard unchanged.

## Summary
- restrict dashboard ECS service selection to actual dashboard services for the cogent
- prevent `dashboard deploy --docker` from grabbing sibling services like the Discord bridge
- add focused coverage for dashboard service-name filtering and selection behavior

## Testing
- `uv run --with pytest pytest tests/brain/test_update_cli.py -q`
