### PR TITLE
fix dashboard CloudWatch run links

### DIFF
--- a/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
+++ b/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
@@ -7,6 +7,7 @@ import { JsonViewer } from "@/components/shared/JsonViewer";
 import type { CogosFileVersion } from "@/lib/types";
 import * as api from "@/lib/api";
 import { fmtTimestamp } from "@/lib/format";
+import { buildCogentRunLogsUrl } from "@/lib/cloudwatch";
 
 interface Props {
   processes: CogosProcess[];
@@ -34,7 +35,7 @@ const STATUS_VARIANT: Record<string, BadgeVariant> = {
 const STATUSES = ["waiting", "runnable", "running", "completed", "disabled", "blocked", "suspended"];
 const MODES: ("daemon" | "one_shot")[] = ["one_shot", "daemon"];
 const RUNNERS = ["lambda", "ecs"];
-const DEFAULT_MODEL = "us.anthropic.claude-opus-4-20250514-v1:0";
+const EXECUTOR_DEFAULT_MODEL_LABEL = "default (sonnet)";
 
 const INPUT_CLS = "bg-[var(--bg-elevated)] border border-[var(--border)] rounded px-2 py-1 text-[12px] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] w-full";
 
@@ -71,7 +72,7 @@ const EMPTY_FORM: ProcessForm = {
   priority: "0",
   runner: "lambda",
   status: "runnable",
-  model: DEFAULT_MODEL,
+  model: "",
   max_duration_val: "",
   max_duration_unit: "m",
   max_retries: "0",
@@ -117,7 +118,7 @@ function formFromProcess(
     priority: String(p.priority),
     runner: p.runner,
     status: p.status,
-    model: p.model || DEFAULT_MODEL,
+    model: p.model ?? "",
     ...msToFormDuration(p.max_duration_ms),
     max_retries: String(p.max_retries),
     preemptible: p.preemptible,
@@ -145,35 +146,6 @@ function fmtTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
-}
-
-const AWS_REGION = "us-east-1";
-
-function buildCloudWatchUrl(cogentName: string, runId: string, createdAt: string | null): string {
-  const safeName = cogentName.replace(/\./g, "-");
-  const logGroup = `/aws/lambda/cogent-${safeName}-executor`;
-  const query = `fields @timestamp, @message | filter @message like "${runId}" | sort @timestamp asc`;
-  const encodedQuery = encodeURIComponent(query)
-    .replace(/%20/g, "*20")
-    .replace(/%22/g, "*22")
-    .replace(/%7C/g, "*7c")
-    .replace(/%40/g, "*40")
-    .replace(/%0A/g, "*0a");
-  let startParam = "start~-3600~timeType~'RELATIVE~unit~'seconds";
-  if (createdAt) {
-    const ts = new Date(createdAt).getTime();
-    const start = ts - 60 * 60 * 1000;
-    const end = ts + 60 * 60 * 1000;
-    startParam = `start~${start}~end~${end}~timeType~'ABSOLUTE`;
-  }
-  const encodedSource = logGroup.replace(/\//g, "*2f");
-  return (
-    `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}` +
-    `#logsV2:logs-insights$3FqueryDetail$3D~(` +
-    `${startParam}` +
-    `~editorString~'${encodedQuery}` +
-    `~source~(~'${encodedSource}))`
-  );
 }
 
 /* ── TagListEditor: editable list with typeahead ── */
@@ -625,7 +597,7 @@ function TagEditor({
 
 /* ── Last Run Display ── */
 
-function LastRunInfo({ run, cogentName }: { run: CogosProcessRun; cogentName?: string }) {
+function LastRunInfo({ run, cogentName, runner }: { run: CogosProcessRun; cogentName?: string; runner?: string }) {
   const [showResult, setShowResult] = useState(false);
   return (
     <div
@@ -640,7 +612,7 @@ function LastRunInfo({ run, cogentName }: { run: CogosProcessRun; cogentName?: s
           </Badge>
           {cogentName && (
             <a
-              href={buildCloudWatchUrl(cogentName, run.id, run.created_at)}
+              href={buildCogentRunLogsUrl(cogentName, run.id, run.created_at, runner)}
               target="_blank"
               rel="noopener noreferrer"
               className="text-[var(--accent)] text-[10px] hover:underline"
@@ -789,18 +761,20 @@ function StatusMenu({ value, onChange }: { value: string; onChange: (s: string) 
 /* ── Model Menu Button ── */
 
 const MODELS = [
+  { value: "", label: EXECUTOR_DEFAULT_MODEL_LABEL },
   { value: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "haiku" },
   { value: "us.anthropic.claude-sonnet-4-20250514-v1:0", label: "sonnet" },
   { value: "us.anthropic.claude-opus-4-20250514-v1:0", label: "opus" },
 ];
 
 function modelLabel(value: string): string {
+  if (!value) return EXECUTOR_DEFAULT_MODEL_LABEL;
   const m = MODELS.find((m) => m.value === value);
   if (m) return m.label;
   if (value.includes("haiku")) return "haiku";
   if (value.includes("opus")) return "opus";
   if (value.includes("sonnet")) return "sonnet";
-  return value || "opus";
+  return value;
 }
 
 function ModelMenu({ value, onChange }: { value: string; onChange: (m: string) => void }) {
@@ -1810,7 +1784,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                   <span className="inline-flex items-center justify-center w-[22px] h-[18px]">
                     {lastRun ? (
                       <a
-                        href={buildCloudWatchUrl(cogentName, lastRun.id, lastRun.created_at)}
+                        href={buildCogentRunLogsUrl(cogentName, lastRun.id, lastRun.created_at, proc.runner)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-[10px] font-mono px-1 py-0 rounded hover:underline"
@@ -2035,7 +2009,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                               <td className="px-2 py-1 text-red-400 text-[10px] truncate max-w-[200px]" title={run.error || ""}>{run.error ? (run.error.length > 30 ? run.error.slice(0, 30) + "…" : run.error) : ""}</td>
                               <td className="px-2 py-1 text-right">
                                 <a
-                                  href={buildCloudWatchUrl(cogentName, run.id, run.created_at)}
+                                  href={buildCogentRunLogsUrl(cogentName, run.id, run.created_at, proc.runner)}
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   className="text-[var(--accent)] text-[10px] hover:underline"

--- a/dashboard/frontend/src/components/runs/RunsPanel.tsx
+++ b/dashboard/frontend/src/components/runs/RunsPanel.tsx
@@ -4,6 +4,7 @@ import type { CogosRun } from "@/lib/types";
 import { Badge } from "@/components/shared/Badge";
 import { DataTable, type Column } from "@/components/shared/DataTable";
 import { fmtTimestamp, fmtMs, fmtCost, fmtNum } from "@/lib/format";
+import { buildCogentRunLogsUrl } from "@/lib/cloudwatch";
 
 interface Props {
   runs: CogosRun[];
@@ -29,43 +30,6 @@ const STATUS_ABBREV: Record<string, string> = {
   timeout: "T",
   pending: "P",
 };
-
-const AWS_REGION = "us-east-1";
-
-function buildCloudWatchUrl(cogentName: string, runId: string, createdAt: string | null): string {
-  const safeName = cogentName.replace(/\./g, "-");
-  const logGroup = `/aws/lambda/cogent-${safeName}-executor`;
-  const encodedLogGroup = logGroup.replace(/\//g, "$252F");
-
-  // Build a Logs Insights query URL filtered by run ID
-  const query = `fields @timestamp, @message | filter @message like "${runId}" | sort @timestamp asc`;
-  const encodedQuery = encodeURIComponent(query)
-    .replace(/%20/g, "*20")
-    .replace(/%22/g, "*22")
-    .replace(/%7C/g, "*7c")
-    .replace(/%40/g, "*40")
-    .replace(/%0A/g, "*0a");
-
-  // Time window: 1 hour before created_at to 1 hour after (or now)
-  let startParam = "start~-3600~timeType~'RELATIVE~unit~'seconds";
-  if (createdAt) {
-    const ts = new Date(createdAt).getTime();
-    const start = ts - 60 * 60 * 1000;
-    const end = ts + 60 * 60 * 1000;
-    startParam = `start~${start}~end~${end}~timeType~'ABSOLUTE`;
-  }
-
-  const encodedSource = logGroup
-    .replace(/\//g, "*2f");
-
-  return (
-    `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}` +
-    `#logsV2:logs-insights$3FqueryDetail$3D~(` +
-    `${startParam}` +
-    `~editorString~'${encodedQuery}` +
-    `~source~(~'${encodedSource}))`
-  );
-}
 
 function makeColumns(cogentName?: string): Column<CogosRun & Record<string, unknown>>[] {
   const cols: Column<CogosRun & Record<string, unknown>>[] = [
@@ -144,7 +108,7 @@ function makeColumns(cogentName?: string): Column<CogosRun & Record<string, unkn
       label: "Logs",
       render: (row) => (
         <a
-          href={buildCloudWatchUrl(cogentName, row.id, row.created_at)}
+          href={buildCogentRunLogsUrl(cogentName, row.id, row.created_at, row.runner)}
           target="_blank"
           rel="noopener noreferrer"
           className="text-[var(--accent)] text-xs hover:underline"

--- a/dashboard/frontend/src/lib/cloudwatch.ts
+++ b/dashboard/frontend/src/lib/cloudwatch.ts
@@ -1,0 +1,97 @@
+const AWS_REGION = "us-east-1";
+
+type QueryDetail = Record<string, string[]>;
+
+function queryEscape(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function ecmaEscape(value: string): string {
+  let out = "";
+
+  for (const char of value) {
+    const code = char.codePointAt(0);
+    if (code == null) continue;
+
+    const isAlphaNum =
+      (code >= 0x30 && code <= 0x39) ||
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a);
+    const isSafePunct = "@*_+-./".includes(char);
+    if (isAlphaNum || isSafePunct) {
+      out += char;
+      continue;
+    }
+
+    const width = code >= 0x100 ? 4 : 2;
+    out += `%${code.toString(16).toUpperCase().padStart(width, "0")}`;
+  }
+
+  return out;
+}
+
+function addDetailValue(detail: QueryDetail, key: string, value: string, quote = false): void {
+  const encoded = queryEscape(value).replace(/%/g, "*");
+  const nextValue = quote ? `'${encoded}` : encoded;
+  detail[key] = [...(detail[key] ?? []), nextValue];
+}
+
+function encodeQueryDetail(detail: QueryDetail): string {
+  const parts = Object.entries(detail)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, values]) => {
+      if (values.length === 1) {
+        return `${key}~${values[0]}`;
+      }
+      return `${key}~(${values.map((value) => `~${value}`).join("")})`;
+    });
+
+  const encoded = queryEscape(`?queryDetail=${ecmaEscape(`~(${parts.join("~")})`)}`);
+  return encoded.replace(/%/g, "$");
+}
+
+function executorLogGroup(cogentName: string, runner: string | null | undefined): string {
+  const safeName = cogentName.replace(/\./g, "-");
+  if (runner === "ecs") {
+    return `/ecs/cogent-${safeName}-executor`;
+  }
+  return `/aws/lambda/cogent-${safeName}-executor`;
+}
+
+function addTimeRange(detail: QueryDetail, createdAt: string | null): void {
+  const timestamp = createdAt ? Date.parse(createdAt) : Number.NaN;
+  if (Number.isFinite(timestamp)) {
+    const start = Math.max(timestamp - 60 * 60 * 1000, 0);
+    const end = Math.max(timestamp + 60 * 60 * 1000, Date.now());
+    addDetailValue(detail, "start", String(start));
+    addDetailValue(detail, "end", String(end));
+    addDetailValue(detail, "timeType", "ABSOLUTE", true);
+    return;
+  }
+
+  addDetailValue(detail, "start", "-3600");
+  addDetailValue(detail, "end", "0");
+  addDetailValue(detail, "timeType", "RELATIVE", true);
+  addDetailValue(detail, "unit", "seconds", true);
+}
+
+export function buildCogentRunLogsUrl(
+  cogentName: string,
+  runId: string,
+  createdAt: string | null,
+  runner?: string | null,
+): string {
+  const detail: QueryDetail = {};
+  const logGroup = executorLogGroup(cogentName, runner);
+  const query = [
+    "fields @timestamp, @message, @logStream, run_id",
+    `| filter run_id = "${runId}" or @message like /${runId}/`,
+    "| sort @timestamp asc",
+  ].join("\n");
+
+  addTimeRange(detail, createdAt);
+  addDetailValue(detail, "editorString", query, true);
+  addDetailValue(detail, "source", logGroup, true);
+
+  return `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#logsV2:logs-insights${encodeQueryDetail(detail)}`;
+}

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -115,6 +115,7 @@ export interface CogosRun {
   id: string;
   process: string;
   process_name?: string;
+  runner?: string | null;
   status: string;
   tokens_in: number;
   tokens_out: number;

--- a/src/brain/cdk/constructs/compute.py
+++ b/src/brain/cdk/constructs/compute.py
@@ -7,11 +7,12 @@ import shutil
 import subprocess
 import tempfile
 
-from aws_cdk import Duration
+from aws_cdk import Duration, RemovalPolicy
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_logs as logs
 from aws_cdk import aws_s3 as s3
 from constructs import Construct
 
@@ -335,10 +336,20 @@ class ComputeConstruct(Construct):
         else:
             image = ecs.ContainerImage.from_registry("python:3.12-slim")
 
+        self.executor_task_log_group = logs.LogGroup(
+            self,
+            "ExecutorTaskExecutorLogGroup",
+            log_group_name=f"/ecs/cogent-{safe_name}-executor",
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
         self.task_definition.add_container(
             "Executor",
             image=image,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix="executor"),
+            logging=ecs.LogDrivers.aws_logs(
+                stream_prefix="executor",
+                log_group=self.executor_task_log_group,
+            ),
             environment={
                 **env,
                 "CLAUDE_CODE_USE_BEDROCK": "1",

--- a/src/dashboard/routers/runs.py
+++ b/src/dashboard/routers/runs.py
@@ -21,6 +21,7 @@ class RunSummary(BaseModel):
     id: str
     process: str
     process_name: str | None = None
+    runner: str | None = None
     event: str | None = None
     conversation: str | None = None
     status: str
@@ -60,11 +61,16 @@ class RunsResponse(BaseModel):
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
-def _summary(r: Run, process_names: dict[UUID, str] | None = None) -> RunSummary:
+def _summary(
+    r: Run,
+    process_names: dict[UUID, str] | None = None,
+    process_runners: dict[UUID, str] | None = None,
+) -> RunSummary:
     return RunSummary(
         id=str(r.id),
         process=str(r.process),
         process_name=process_names.get(r.process) if process_names else None,
+        runner=process_runners.get(r.process) if process_runners else None,
         event=str(r.event) if r.event else None,
         conversation=str(r.conversation) if r.conversation else None,
         status=r.status.value,
@@ -113,7 +119,8 @@ def list_runs(
     items = repo.list_runs(process_id=pid, limit=limit)
     processes = repo.list_processes()
     process_names = {p.id: p.name for p in processes}
-    out = [_summary(r, process_names) for r in items]
+    process_runners = {p.id: p.runner for p in processes}
+    out = [_summary(r, process_names, process_runners) for r in items]
     return RunsResponse(count=len(out), runs=out)
 
 


### PR DESCRIPTION
**Problem**

Dashboard run links always targeted the Lambda executor log group and hand-built the CloudWatch Logs Insights fragment in two different ways. That made log links brittle and sent ECS-backed runs to a place that did not actually show the run logs.

**Summary**

- centralize CloudWatch Logs Insights URL generation in a shared frontend helper with deterministic AWS fragment encoding
- pass runner metadata through the runs API so the dashboard can target Lambda and ECS executor logs correctly
- give ECS executor tasks a stable /ecs/cogent-{name}-executor log group so dashboard links do not depend on CloudFormation-generated names