### PR TITLE
Request Bedrock quota increases during polis provisioning

### DIFF
--- a/src/polis/cdk/stacks/core.py
+++ b/src/polis/cdk/stacks/core.py
@@ -192,6 +192,25 @@ class PolisStack(cdk.Stack):
                 resources=["*"],
             )
         )
+        self.admin_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "servicequotas:GetAWSDefaultServiceQuota",
+                    "servicequotas:GetServiceQuota",
+                    "servicequotas:ListRequestedServiceQuotaChangeHistoryByQuota",
+                    "servicequotas:ListServiceQuotas",
+                    "servicequotas:RequestServiceQuotaIncrease",
+                ],
+                resources=["*"],
+            )
+        )
+        self.admin_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["iam:CreateServiceLinkedRole"],
+                resources=["*"],
+                conditions={"StringLike": {"iam:AWSServiceName": "servicequotas.amazonaws.com"}},
+            )
+        )
         self.status_table.grant_read_write_data(self.admin_role)
         self.admin_role.add_to_policy(
             iam.PolicyStatement(

--- a/src/polis/cli.py
+++ b/src/polis/cli.py
@@ -25,6 +25,7 @@ from polis.aws import (
     set_profile,
 )
 from polis.config import PolisConfig
+from polis.quotas import QuotaEnsureResult, ensure_service_quota_targets
 from polis.secrets.store import SecretStore
 from polis.status import coalesce_status_items, expected_stack_name
 
@@ -77,6 +78,7 @@ def create(ctx: click.Context):
 
     # Cloudflare Access
     polis_session, _ = get_polis_session()
+    _ensure_polis_quotas(polis_session, config)
     _ensure_cloudflare_access(polis_session, config.domain)
 
     console.print("[green]Polis created successfully.[/green]")
@@ -95,6 +97,7 @@ def update(ctx: click.Context):
     # Cloudflare Access
     config: PolisConfig = ctx.obj["config"]
     polis_session, _ = get_polis_session()
+    _ensure_polis_quotas(polis_session, config)
     _ensure_cloudflare_access(polis_session, config.domain)
 
     console.print("[green]Polis updated.[/green]")
@@ -373,6 +376,25 @@ def status():
             size_mb = f"{img.get('imageSizeInBytes', 0) / 1024 / 1024:.0f}"
             it.add_row(tags, pushed_str, size_mb)
         console.print(it)
+
+
+# ---------------------------------------------------------------------------
+# Quotas
+# ---------------------------------------------------------------------------
+
+
+@polis.group()
+def quotas():
+    """Manage account-level quota requests."""
+
+
+@quotas.command("ensure")
+@click.pass_context
+def quotas_ensure(ctx: click.Context):
+    """Ensure configured Bedrock quota requests exist in the polis account."""
+    config: PolisConfig = ctx.obj["config"]
+    polis_session, _ = get_polis_session()
+    _ensure_polis_quotas(polis_session, config, fail_on_error=True)
 
 
 # ---------------------------------------------------------------------------
@@ -782,6 +804,52 @@ def _ensure_cloudflare_access(session, domain: str = "softmax-cogents.com") -> N
         console.print(f"  Cloudflare Access: [green]ok[/green] ({app['id']})")
     except Exception as e:
         console.print(f"  [yellow]Cloudflare Access: {e}[/yellow]")
+
+
+def _ensure_polis_quotas(
+    session,
+    config: PolisConfig,
+    *,
+    fail_on_error: bool = False,
+) -> list[QuotaEnsureResult]:
+    """Ensure Bedrock quota requests exist for the shared polis account."""
+    if not config.bedrock_quotas:
+        return []
+
+    console.print("  Ensuring Bedrock quotas...")
+    results = ensure_service_quota_targets(session, config.bedrock_quotas)
+
+    failures = []
+    for result in results:
+        current = "-" if result.current_value is None else f"{result.current_value:g}"
+        desired = f"{result.desired_value:g}"
+        if result.status == "satisfied":
+            console.print(
+                f"    [green]ok[/green] {result.quota_name}: current {current} >= desired {desired}"
+            )
+        elif result.status == "requested":
+            detail = f"request {result.request_id}" if result.request_id else "request submitted"
+            console.print(
+                f"    [yellow]requested[/yellow] {result.quota_name}: current {current} -> desired {desired} ({detail})"
+            )
+        elif result.status == "pending":
+            request_id = result.request_id or "pending"
+            console.print(
+                f"    [cyan]pending[/cyan] {result.quota_name}: "
+                f"current {current}, desired {desired} ({request_id})"
+            )
+        else:
+            failures.append(result)
+            note = f" ({result.note})" if result.note else ""
+            console.print(
+                f"    [yellow]{result.status}[/yellow] {result.quota_name}: current {current}, desired {desired}{note}"
+            )
+
+    if fail_on_error and failures:
+        names = ", ".join(result.quota_code for result in failures)
+        raise click.ClickException(f"Quota ensure did not fully succeed: {names}")
+
+    return results
 
 
 def _cdk_deploy(org_id: str, profile: str | None = None):

--- a/src/polis/config.py
+++ b/src/polis/config.py
@@ -2,12 +2,36 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class CogentMeta(BaseModel):
     description: str = ""
     personality: str | None = None
+
+
+class ServiceQuotaTarget(BaseModel):
+    service_code: str = "bedrock"
+    quota_code: str
+    quota_name: str
+    desired_value: float
+    region: str = "us-east-1"
+
+
+def _default_bedrock_quotas() -> list[ServiceQuotaTarget]:
+    """Default Bedrock quota targets for the shared polis account."""
+    return [
+        ServiceQuotaTarget(
+            quota_code="L-59759B4A",
+            quota_name="Cross-region model inference tokens per minute for Anthropic Claude Sonnet 4 V1",
+            desired_value=1_000_000,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-559DCC33",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Sonnet 4 V1",
+            desired_value=500,
+        ),
+    ]
 
 
 class PolisConfig(BaseModel):
@@ -16,6 +40,7 @@ class PolisConfig(BaseModel):
     owner: str = "daveey"
     domain: str = "softmax-cogents.com"
     cogents: dict[str, CogentMeta] = {}
+    bedrock_quotas: list[ServiceQuotaTarget] = Field(default_factory=_default_bedrock_quotas)
 
     def template_vars(self, cogent_name: str) -> dict[str, str]:
         """Return template variables for a cogent."""

--- a/src/polis/quotas.py
+++ b/src/polis/quotas.py
@@ -1,0 +1,143 @@
+"""Service Quotas helpers for polis account provisioning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+from polis.config import ServiceQuotaTarget
+
+_ACTIVE_REQUEST_STATUSES = {"PENDING", "CASE_OPENED"}
+
+
+@dataclass(frozen=True)
+class QuotaEnsureResult:
+    quota_code: str
+    quota_name: str
+    desired_value: float
+    region: str
+    status: str
+    current_value: float | None = None
+    request_id: str | None = None
+    note: str = ""
+
+
+def ensure_service_quota_targets(
+    session: Any,
+    targets: list[ServiceQuotaTarget],
+) -> list[QuotaEnsureResult]:
+    """Ensure each quota target has either enough headroom or an open request."""
+    results: list[QuotaEnsureResult] = []
+    clients: dict[tuple[str, str], Any] = {}
+
+    for target in targets:
+        client_key = (target.service_code, target.region)
+        client = clients.get(client_key)
+        if client is None:
+            client = session.client("service-quotas", region_name=target.region)
+            clients[client_key] = client
+        results.append(_ensure_service_quota_target(client, target))
+
+    return results
+
+
+def _ensure_service_quota_target(client: Any, target: ServiceQuotaTarget) -> QuotaEnsureResult:
+    quota = _get_quota(client, target)
+    current_value = float(quota.get("Value", 0))
+    adjustable = quota.get("Adjustable", False)
+
+    if current_value >= target.desired_value:
+        return QuotaEnsureResult(
+            quota_code=target.quota_code,
+            quota_name=target.quota_name,
+            desired_value=target.desired_value,
+            region=target.region,
+            status="satisfied",
+            current_value=current_value,
+        )
+
+    pending = _find_pending_request(client, target)
+    if pending:
+        pending_value = float(pending.get("DesiredValue", 0))
+        status = "pending" if pending_value >= target.desired_value else "pending_lower_value"
+        note = ""
+        if pending_value < target.desired_value:
+            note = f"open request targets {pending_value:g}, below desired {target.desired_value:g}"
+        return QuotaEnsureResult(
+            quota_code=target.quota_code,
+            quota_name=target.quota_name,
+            desired_value=target.desired_value,
+            region=target.region,
+            status=status,
+            current_value=current_value,
+            request_id=pending.get("Id"),
+            note=note,
+        )
+
+    if not adjustable:
+        return QuotaEnsureResult(
+            quota_code=target.quota_code,
+            quota_name=target.quota_name,
+            desired_value=target.desired_value,
+            region=target.region,
+            status="not_adjustable",
+            current_value=current_value,
+            note="quota is not adjustable via Service Quotas",
+        )
+
+    try:
+        response = client.request_service_quota_increase(
+            ServiceCode=target.service_code,
+            QuotaCode=target.quota_code,
+            DesiredValue=target.desired_value,
+        )
+    except ClientError as exc:
+        return QuotaEnsureResult(
+            quota_code=target.quota_code,
+            quota_name=target.quota_name,
+            desired_value=target.desired_value,
+            region=target.region,
+            status="error",
+            current_value=current_value,
+            note=str(exc),
+        )
+
+    requested = response.get("RequestedQuota", {})
+    return QuotaEnsureResult(
+        quota_code=target.quota_code,
+        quota_name=target.quota_name,
+        desired_value=target.desired_value,
+        region=target.region,
+        status="requested",
+        current_value=current_value,
+        request_id=requested.get("Id"),
+    )
+
+
+def _get_quota(client: Any, target: ServiceQuotaTarget) -> dict[str, Any]:
+    try:
+        return client.get_service_quota(
+            ServiceCode=target.service_code,
+            QuotaCode=target.quota_code,
+        )["Quota"]
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") != "NoSuchResourceException":
+            raise
+        return client.get_aws_default_service_quota(
+            ServiceCode=target.service_code,
+            QuotaCode=target.quota_code,
+        )["Quota"]
+
+
+def _find_pending_request(client: Any, target: ServiceQuotaTarget) -> dict[str, Any] | None:
+    response = client.list_requested_service_quota_change_history_by_quota(
+        ServiceCode=target.service_code,
+        QuotaCode=target.quota_code,
+    )
+    requested = response.get("RequestedQuotas", [])
+    pending = [item for item in requested if item.get("Status") in _ACTIVE_REQUEST_STATUSES]
+    if not pending:
+        return None
+    return max(pending, key=lambda item: float(item.get("DesiredValue", 0)))

--- a/tests/polis/test_cli.py
+++ b/tests/polis/test_cli.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from polis.cli import polis
+
+
+def test_update_ensures_polis_quotas(monkeypatch):
+    calls: list[tuple] = []
+
+    monkeypatch.setattr("polis.cli.get_org_id", lambda: "o-test")
+    monkeypatch.setattr("polis.cli._cdk_deploy", lambda org_id, profile=None: calls.append(("deploy", org_id, profile)))
+    monkeypatch.setattr("polis.cli.get_polis_session", lambda: ("session", "901289084804"))
+    monkeypatch.setattr(
+        "polis.cli._ensure_polis_quotas",
+        lambda session, config, **kwargs: calls.append(("quotas", session, config.domain)),
+    )
+    monkeypatch.setattr(
+        "polis.cli._ensure_cloudflare_access",
+        lambda session, domain: calls.append(("cloudflare", session, domain)),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(polis, ["update"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        ("deploy", "o-test", "softmax-org"),
+        ("quotas", "session", "softmax-cogents.com"),
+        ("cloudflare", "session", "softmax-cogents.com"),
+    ]
+
+
+def test_quotas_ensure_runs_quota_helper(monkeypatch):
+    calls: list[tuple] = []
+
+    monkeypatch.setattr("polis.cli.get_polis_session", lambda: ("session", "901289084804"))
+    monkeypatch.setattr(
+        "polis.cli._ensure_polis_quotas",
+        lambda session, config, **kwargs: calls.append(("quotas", session, config.domain, kwargs.get("fail_on_error"))),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(polis, ["quotas", "ensure"])
+
+    assert result.exit_code == 0
+    assert calls == [("quotas", "session", "softmax-cogents.com", True)]

--- a/tests/polis/test_quotas.py
+++ b/tests/polis/test_quotas.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from polis.config import ServiceQuotaTarget
+from polis.quotas import ensure_service_quota_targets
+
+
+class _FakeServiceQuotasClient:
+    def __init__(self, *, quotas=None, history=None):
+        self.quotas = quotas or {}
+        self.history = history or {}
+        self.requests: list[dict] = []
+
+    def get_service_quota(self, *, ServiceCode: str, QuotaCode: str):
+        return {"Quota": self.quotas[(ServiceCode, QuotaCode)]}
+
+    def get_aws_default_service_quota(self, *, ServiceCode: str, QuotaCode: str):
+        return {"Quota": self.quotas[(ServiceCode, QuotaCode)]}
+
+    def list_requested_service_quota_change_history_by_quota(self, *, ServiceCode: str, QuotaCode: str):
+        return {"RequestedQuotas": self.history.get((ServiceCode, QuotaCode), [])}
+
+    def request_service_quota_increase(self, *, ServiceCode: str, QuotaCode: str, DesiredValue: float):
+        request = {
+            "ServiceCode": ServiceCode,
+            "QuotaCode": QuotaCode,
+            "DesiredValue": DesiredValue,
+        }
+        self.requests.append(request)
+        return {"RequestedQuota": {"Id": "req-123", "DesiredValue": DesiredValue}}
+
+
+class _FakeSession:
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, service_name: str, region_name: str | None = None):
+        assert service_name == "service-quotas"
+        assert region_name == "us-east-1"
+        return self._client
+
+
+def test_ensure_service_quota_targets_requests_increase_when_below_desired():
+    client = _FakeServiceQuotasClient(
+        quotas={
+            ("bedrock", "L-1"): {
+                "Value": 200,
+                "Adjustable": True,
+            }
+        }
+    )
+    session = _FakeSession(client)
+    targets = [
+        ServiceQuotaTarget(
+            quota_code="L-1",
+            quota_name="Test quota",
+            desired_value=500,
+        )
+    ]
+
+    results = ensure_service_quota_targets(session, targets)
+
+    assert client.requests == [{"ServiceCode": "bedrock", "QuotaCode": "L-1", "DesiredValue": 500}]
+    assert results[0].status == "requested"
+    assert results[0].current_value == 200
+
+
+def test_ensure_service_quota_targets_skips_when_pending_request_is_already_open():
+    client = _FakeServiceQuotasClient(
+        quotas={
+            ("bedrock", "L-1"): {
+                "Value": 200,
+                "Adjustable": True,
+            }
+        },
+        history={
+            ("bedrock", "L-1"): [
+                {
+                    "Id": "req-999",
+                    "Status": "PENDING",
+                    "DesiredValue": 500,
+                }
+            ]
+        },
+    )
+    session = _FakeSession(client)
+    targets = [
+        ServiceQuotaTarget(
+            quota_code="L-1",
+            quota_name="Test quota",
+            desired_value=500,
+        )
+    ]
+
+    results = ensure_service_quota_targets(session, targets)
+
+    assert client.requests == []
+    assert results[0].status == "pending"
+    assert results[0].request_id == "req-999"
+
+
+def test_ensure_service_quota_targets_skips_when_current_value_is_sufficient():
+    client = _FakeServiceQuotasClient(
+        quotas={
+            ("bedrock", "L-1"): {
+                "Value": 750,
+                "Adjustable": True,
+            }
+        }
+    )
+    session = _FakeSession(client)
+    targets = [
+        ServiceQuotaTarget(
+            quota_code="L-1",
+            quota_name="Test quota",
+            desired_value=500,
+        )
+    ]
+
+    results = ensure_service_quota_targets(session, targets)
+
+    assert client.requests == []
+    assert results[0].status == "satisfied"
+    assert results[0].current_value == 750


### PR DESCRIPTION
Problem

All cogents share the Bedrock quota pool in the polis account, but polis provisioning had no explicit way to inspect or request more headroom for the shared default model. The current polis admin role also could not call Service Quotas APIs, which meant operators had to leave the repo to diagnose or request Bedrock quota changes.

Summary

- add configurable Bedrock quota targets to PolisConfig and a Service Quotas helper that requests increases or reuses pending requests
- run quota ensure from polis create/update and expose a manual polis quotas ensure command for re-running the workflow
- grant Service Quotas permissions to cogent-polis-admin and cover the helper and CLI integration with tests

Testing

- uv run python -m pytest tests/polis/test_aws.py tests/polis/test_quotas.py tests/polis/test_cli.py