### PR TITLE
Track Claude 4.5 and 4.6 quota targets in polis config

### DIFF
--- a/src/polis/config.py
+++ b/src/polis/config.py
@@ -31,6 +31,46 @@ def _default_bedrock_quotas() -> list[ServiceQuotaTarget]:
             quota_name="Cross-region model inference requests per minute for Anthropic Claude Sonnet 4 V1",
             desired_value=500,
         ),
+        ServiceQuotaTarget(
+            quota_code="L-CCA5DF70",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Haiku 4.5",
+            desired_value=10_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-27989F42",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Opus 4.5",
+            desired_value=10_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-11DFF789",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Opus 4.6 V1",
+            desired_value=10_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-410BCACA",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Opus 4.6 V1 1M Context Length",
+            desired_value=1_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-4A6BFAB1",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Sonnet 4.5 V1",
+            desired_value=10_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-A052927A",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Sonnet 4.5 V1 1M Context Length",
+            desired_value=1_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-00FF3314",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Sonnet 4.6",
+            desired_value=10_001,
+        ),
+        ServiceQuotaTarget(
+            quota_code="L-47DE5258",
+            quota_name="Cross-region model inference requests per minute for Anthropic Claude Sonnet 4.6 1M Context Length",
+            desired_value=1_001,
+        ),
     ]
 
 

--- a/tests/polis/test_quotas.py
+++ b/tests/polis/test_quotas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from polis.config import ServiceQuotaTarget
+from polis.config import PolisConfig, ServiceQuotaTarget
 from polis.quotas import ensure_service_quota_targets
 
 
@@ -121,3 +121,17 @@ def test_ensure_service_quota_targets_skips_when_current_value_is_sufficient():
     assert client.requests == []
     assert results[0].status == "satisfied"
     assert results[0].current_value == 750
+
+
+def test_default_polis_config_tracks_claude_45_and_46_rpm_targets():
+    quotas = {quota.quota_code: quota.desired_value for quota in PolisConfig().bedrock_quotas}
+
+    assert quotas["L-559DCC33"] == 500
+    assert quotas["L-CCA5DF70"] == 10_001
+    assert quotas["L-27989F42"] == 10_001
+    assert quotas["L-11DFF789"] == 10_001
+    assert quotas["L-410BCACA"] == 1_001
+    assert quotas["L-4A6BFAB1"] == 10_001
+    assert quotas["L-A052927A"] == 1_001
+    assert quotas["L-00FF3314"] == 10_001
+    assert quotas["L-47DE5258"] == 1_001


### PR DESCRIPTION
Problem

The initial polis quota automation only tracked Claude Sonnet 4 V1. We already needed to open additional Bedrock RPM requests for the Claude 4.5 and 4.6 families, but future polis quota syncs would not preserve or re-request those targets.

Summary

- add the Claude 4.5 and 4.6 cross-region RPM quota targets to the default polis Bedrock quota set
- use the minimum valid desired RPM values for the standard and 1M-context variants so future polis quota syncs match the live requests we opened
- extend the quota tests so the default config coverage includes the new quota codes

Testing

- uv run python -m pytest tests/polis/test_aws.py tests/polis/test_quotas.py tests/polis/test_cli.py