### PR TITLE
fix(brain): autostart configured Discord bridges after deploy

### DIFF
--- a/src/brain/cdk/stack.py
+++ b/src/brain/cdk/stack.py
@@ -241,7 +241,8 @@ class BrainStack(Stack):
             self.compute.task_definition.task_role
         )
 
-        # Fargate service (starts with 0 desired — use CLI to start)
+        # Fargate service starts stopped by default. CLI flows can auto-start it
+        # after deploy when the Discord token is already configured.
         sg = ec2.SecurityGroup(self, "DiscordSg", vpc=vpc, allow_all_outbound=True)
 
         self.discord_service = ecs.FargateService(

--- a/src/brain/cli.py
+++ b/src/brain/cli.py
@@ -188,6 +188,7 @@ def create_cmd(ctx: click.Context, profile: str | None, watch: bool):
 
     from brain.update_cli import (
         _build_dashboard_tarball,
+        _ensure_discord_bridge_state,
         _get_polis_admin_session,
         _sessions_bucket_name,
         _upload_dashboard_tarball,
@@ -301,11 +302,27 @@ def create_cmd(ctx: click.Context, profile: str | None, watch: bool):
     # Apply database schema
     click.echo("Applying database schema...")
     from cogos.db.migrations import apply_schema
+    schema_ready = False
     try:
         apply_schema()
+        schema_ready = True
         click.echo("Database schema applied.")
     except Exception as e:
         click.echo(f"Warning: schema apply failed: {e}")
+
+    if schema_ready:
+        try:
+            discord_action = _ensure_discord_bridge_state(
+                polis_session,
+                name,
+                safe_name,
+                previous_desired_count=None,
+            )
+        except Exception as e:
+            click.echo(f"Warning: could not reconcile Discord bridge state: {e}")
+        else:
+            if discord_action == ("autostarted", 1):
+                click.echo(f"Starting Discord bridge for cogent-{name} because a token is configured...")
 
     # Update Cloudflare DNS to point at the dashboard ALB
     if cert_arn:

--- a/src/brain/update_cli.py
+++ b/src/brain/update_cli.py
@@ -13,6 +13,7 @@ import boto3
 import click
 
 from cli import DefaultCommandGroup, get_cogent_name
+from cogos.io.discord.setup import discord_secret_status, discord_service_status
 from polis.aws import DEFAULT_ORG_PROFILE, ORG_PROFILE_ENV, resolve_org_profile, set_org_profile
 
 DEFAULT_REGION = "us-east-1"
@@ -413,6 +414,57 @@ def _find_dashboard_service(ecs_client, safe_name: str) -> str:
     return dash_services[0]
 
 
+def _discord_service_name(safe_name: str) -> str:
+    return f"cogent-{safe_name}-discord"
+
+
+def _get_discord_desired_count(session: boto3.Session, name: str) -> int | None:
+    """Return the current desired count for the Discord bridge service."""
+    service_status, _ = discord_service_status(name, DEFAULT_REGION, session=session)
+    return service_status.get("bridge_desired_count")
+
+
+def _restore_discord_desired_count(ecs_client, safe_name: str, desired_count: int | None) -> None:
+    """Restore Discord desired count after a stack deploy if it was previously running."""
+    if not desired_count or desired_count <= 0:
+        return
+
+    ecs_client.update_service(
+        cluster="cogent-polis",
+        service=_discord_service_name(safe_name),
+        desiredCount=desired_count,
+    )
+
+
+def _ensure_discord_bridge_state(
+    session: boto3.Session,
+    name: str,
+    safe_name: str,
+    *,
+    previous_desired_count: int | None,
+) -> tuple[str, int] | None:
+    """Restore or auto-start the Discord bridge when it is already configured."""
+    ecs_client = session.client("ecs", region_name=DEFAULT_REGION)
+
+    if previous_desired_count and previous_desired_count > 0:
+        _restore_discord_desired_count(ecs_client, safe_name, previous_desired_count)
+        return ("restored", previous_desired_count)
+
+    if previous_desired_count is not None:
+        return None
+
+    secret_configured, _ = discord_secret_status(name, DEFAULT_REGION, session=session)
+    if secret_configured is not True:
+        return None
+
+    current_desired_count = _get_discord_desired_count(session, name)
+    if current_desired_count and current_desired_count > 0:
+        return None
+
+    _restore_discord_desired_count(ecs_client, safe_name, 1)
+    return ("autostarted", 1)
+
+
 def _restart_ecs_service(ecs_client, service_arn: str, skip_health: bool, t0: float):
     """Force a new ECS deployment and optionally wait for stability."""
     click.echo("  Restarting ECS service...")
@@ -720,6 +772,8 @@ def update_stack(ctx: click.Context, profile: str | None):
     except Exception:
         click.echo("Warning: Could not resolve polis ECR repo. Using default image.")
 
+    discord_desired_count = _get_discord_desired_count(session, name)
+
     click.echo(f"Updating CDK stack for cogent-{name}...")
     cmd = [
         "npx",
@@ -736,4 +790,21 @@ def update_stack(ctx: click.Context, profile: str | None):
     result = subprocess.run(cmd, capture_output=False, env=env)
     if result.returncode != 0:
         raise click.ClickException("CDK deploy failed")
+    try:
+        discord_action = _ensure_discord_bridge_state(
+            session,
+            name,
+            safe_name,
+            previous_desired_count=discord_desired_count,
+        )
+    except Exception as e:
+        click.echo(f"Warning: could not reconcile Discord bridge state: {e}")
+    else:
+        if discord_action == ("restored", discord_desired_count):
+            click.echo(
+                f"Restoring Discord bridge desired count to {discord_desired_count} "
+                f"for cogent-{name}..."
+            )
+        elif discord_action == ("autostarted", 1):
+            click.echo(f"Starting Discord bridge for cogent-{name} because a token is configured...")
     click.echo(f"Stack update for cogent-{name} completed.")

--- a/src/cogos/io/discord/setup.py
+++ b/src/cogos/io/discord/setup.py
@@ -1,0 +1,91 @@
+"""Shared Discord setup checks used by dashboard and CLI flows."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+def discord_secret_status(
+    name: str,
+    region: str,
+    *,
+    session: boto3.Session | None = None,
+) -> tuple[bool | None, str | None]:
+    """Return whether the Discord token secret exists and contains an access token."""
+    secret_id = f"cogent/{name}/discord"
+    sm = session.client("secretsmanager", region_name=region) if session else boto3.client(
+        "secretsmanager",
+        region_name=region,
+    )
+    try:
+        resp = sm.get_secret_value(SecretId=secret_id)
+        data = json.loads(resp.get("SecretString", "{}"))
+        return bool(data.get("access_token")), None
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "ResourceNotFoundException":
+            return False, None
+        logger.warning("Discord secret check failed for %s: %s", name, code or exc)
+        return None, code or type(exc).__name__
+    except Exception as exc:
+        logger.warning("Discord secret check failed for %s: %s", name, exc)
+        return None, type(exc).__name__
+
+
+def discord_service_status(
+    name: str,
+    region: str,
+    *,
+    session: boto3.Session | None = None,
+) -> tuple[dict[str, int | str | bool | None], str | None]:
+    """Return ECS status for the Discord bridge service."""
+    safe_name = name.replace(".", "-")
+    service_name = f"cogent-{safe_name}-discord"
+    ecs = session.client("ecs", region_name=region) if session else boto3.client(
+        "ecs",
+        region_name=region,
+    )
+    try:
+        resp = ecs.describe_services(cluster="cogent-polis", services=[service_name])
+        services = resp.get("services", [])
+        if not services:
+            return {
+                "bridge_service_exists": False,
+                "bridge_status": None,
+                "bridge_desired_count": None,
+                "bridge_running_count": None,
+                "bridge_pending_count": None,
+            }, None
+        svc = services[0]
+        return {
+            "bridge_service_exists": True,
+            "bridge_status": svc.get("status"),
+            "bridge_desired_count": svc.get("desiredCount"),
+            "bridge_running_count": svc.get("runningCount"),
+            "bridge_pending_count": svc.get("pendingCount"),
+        }, None
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        logger.warning("Discord service check failed for %s: %s", name, code or exc)
+        return {
+            "bridge_service_exists": None,
+            "bridge_status": None,
+            "bridge_desired_count": None,
+            "bridge_running_count": None,
+            "bridge_pending_count": None,
+        }, code or type(exc).__name__
+    except Exception as exc:
+        logger.warning("Discord service check failed for %s: %s", name, exc)
+        return {
+            "bridge_service_exists": None,
+            "bridge_status": None,
+            "bridge_desired_count": None,
+            "bridge_running_count": None,
+            "bridge_pending_count": None,
+        }, type(exc).__name__

--- a/src/dashboard/routers/setup.py
+++ b/src/dashboard/routers/setup.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 from enum import Enum
 
-import boto3
-from botocore.exceptions import ClientError
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from cogos.io.discord.setup import discord_secret_status, discord_service_status
 from dashboard.db import get_repo
 
 logger = logging.getLogger(__name__)
@@ -53,69 +51,6 @@ class ChannelSetup(BaseModel):
 class SetupResponse(BaseModel):
     channels: list[ChannelSetup]
 
-
-def _discord_secret_status(name: str, region: str) -> tuple[bool | None, str | None]:
-    secret_id = f"cogent/{name}/discord"
-    sm = boto3.client("secretsmanager", region_name=region)
-    try:
-        resp = sm.get_secret_value(SecretId=secret_id)
-        data = json.loads(resp.get("SecretString", "{}"))
-        return bool(data.get("access_token")), None
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code == "ResourceNotFoundException":
-            return False, None
-        logger.warning("Discord secret check failed for %s: %s", name, code or exc)
-        return None, code or type(exc).__name__
-    except Exception as exc:
-        logger.warning("Discord secret check failed for %s: %s", name, exc)
-        return None, type(exc).__name__
-
-
-def _discord_service_status(name: str, region: str) -> tuple[dict[str, int | str | bool | None], str | None]:
-    safe_name = name.replace(".", "-")
-    service_name = f"cogent-{safe_name}-discord"
-    ecs = boto3.client("ecs", region_name=region)
-    try:
-        resp = ecs.describe_services(cluster="cogent-polis", services=[service_name])
-        services = resp.get("services", [])
-        if not services:
-            return {
-                "bridge_service_exists": False,
-                "bridge_status": None,
-                "bridge_desired_count": None,
-                "bridge_running_count": None,
-                "bridge_pending_count": None,
-            }, None
-        svc = services[0]
-        return {
-            "bridge_service_exists": True,
-            "bridge_status": svc.get("status"),
-            "bridge_desired_count": svc.get("desiredCount"),
-            "bridge_running_count": svc.get("runningCount"),
-            "bridge_pending_count": svc.get("pendingCount"),
-        }, None
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        logger.warning("Discord service check failed for %s: %s", name, code or exc)
-        return {
-            "bridge_service_exists": None,
-            "bridge_status": None,
-            "bridge_desired_count": None,
-            "bridge_running_count": None,
-            "bridge_pending_count": None,
-        }, code or type(exc).__name__
-    except Exception as exc:
-        logger.warning("Discord service check failed for %s: %s", name, exc)
-        return {
-            "bridge_service_exists": None,
-            "bridge_status": None,
-            "bridge_desired_count": None,
-            "bridge_running_count": None,
-            "bridge_pending_count": None,
-        }, type(exc).__name__
-
-
 def _build_discord_setup(name: str) -> ChannelSetup:
     region = os.environ.get("AWS_REGION", "us-east-1")
     safe_name = name.replace(".", "-")
@@ -155,8 +90,8 @@ def _build_discord_setup(name: str) -> ChannelSetup:
         cogos_initialized = False
         cogos_error = type(exc).__name__
 
-    secret_configured, secret_check_error = _discord_secret_status(name, region)
-    service_status, service_check_error = _discord_service_status(name, region)
+    secret_configured, secret_check_error = discord_secret_status(name, region)
+    service_status, service_check_error = discord_service_status(name, region)
     bridge_running = (
         service_status["bridge_running_count"] is not None
         and int(service_status["bridge_running_count"]) > 0

--- a/tests/brain/test_update_cli.py
+++ b/tests/brain/test_update_cli.py
@@ -1,18 +1,64 @@
 from __future__ import annotations
 
 import pytest
+from botocore.exceptions import ClientError
 from click.testing import CliRunner
 
-from brain.update_cli import _find_dashboard_service, _is_dashboard_service_name, update
+from brain.update_cli import (
+    _ensure_discord_bridge_state,
+    _find_dashboard_service,
+    _get_discord_desired_count,
+    _is_dashboard_service_name,
+    update,
+)
+from cogos.io.discord.setup import discord_secret_status
 
 
 class _FakeEcsClient:
     def __init__(self, service_arns: list[str]):
         self.service_arns = service_arns
+        self.describe_services_response: dict[str, list[dict]] = {"services": []}
+        self.update_calls: list[dict] = []
 
     def list_services(self, cluster: str) -> dict[str, list[str]]:
         assert cluster == "cogent-polis"
         return {"serviceArns": self.service_arns}
+
+    def describe_services(self, cluster: str, services: list[str]) -> dict[str, list[dict]]:
+        assert cluster == "cogent-polis"
+        assert services
+        return self.describe_services_response
+
+    def update_service(self, **kwargs) -> None:
+        self.update_calls.append(kwargs)
+
+
+class _FakeSession:
+    def __init__(self, *, ecs_client, acm_client, ecr_client, secrets_client):
+        self._clients = {
+            "ecs": ecs_client,
+            "acm": acm_client,
+            "ecr": ecr_client,
+            "secretsmanager": secrets_client,
+        }
+
+    def client(self, name: str, region_name: str | None = None):
+        return self._clients[name]
+
+
+class _FakeSecretsClient:
+    def __init__(self, *, exists: bool):
+        self.exists = exists
+        self.calls: list[str] = []
+
+    def get_secret_value(self, *, SecretId: str) -> dict:
+        self.calls.append(SecretId)
+        if not self.exists:
+            raise ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "not found"}},
+                "GetSecretValue",
+            )
+        return {"SecretString": '{"access_token":"discord-token"}'}
 
 
 def test_is_dashboard_service_name_rejects_non_dashboard_services():
@@ -41,6 +87,146 @@ def test_find_dashboard_service_raises_when_dashboard_service_missing():
 
     with pytest.raises(Exception, match="No dashboard service found"):
         _find_dashboard_service(ecs_client, "dr-gamma")
+
+
+def test_get_discord_desired_count_reads_service():
+    ecs_client = _FakeEcsClient([])
+    ecs_client.describe_services_response = {
+        "services": [{"serviceName": "cogent-dr-gamma-discord", "desiredCount": 1}]
+    }
+    session = _FakeSession(
+        ecs_client=ecs_client,
+        acm_client=object(),
+        ecr_client=object(),
+        secrets_client=_FakeSecretsClient(exists=True),
+    )
+
+    desired = _get_discord_desired_count(session, "dr.gamma")
+
+    assert desired == 1
+
+
+def test_discord_secret_status_checks_expected_secret_name():
+    secrets_client = _FakeSecretsClient(exists=True)
+    session = _FakeSession(
+        ecs_client=_FakeEcsClient([]),
+        acm_client=object(),
+        ecr_client=object(),
+        secrets_client=secrets_client,
+    )
+
+    configured, error = discord_secret_status("dr.gamma", "us-east-1", session=session)
+
+    assert configured is True
+    assert error is None
+    assert secrets_client.calls == ["cogent/dr.gamma/discord"]
+
+
+def test_ensure_discord_bridge_state_autostarts_when_secret_exists():
+    ecs_client = _FakeEcsClient([])
+    ecs_client.describe_services_response = {
+        "services": [{"serviceName": "cogent-dr-gamma-discord", "desiredCount": 0}]
+    }
+    session = _FakeSession(
+        ecs_client=ecs_client,
+        acm_client=object(),
+        ecr_client=object(),
+        secrets_client=_FakeSecretsClient(exists=True),
+    )
+
+    action = _ensure_discord_bridge_state(
+        session,
+        "dr.gamma",
+        "dr-gamma",
+        previous_desired_count=None,
+    )
+
+    assert action == ("autostarted", 1)
+    assert ecs_client.update_calls == [
+        {
+            "cluster": "cogent-polis",
+            "service": "cogent-dr-gamma-discord",
+            "desiredCount": 1,
+        }
+    ]
+
+
+def test_ensure_discord_bridge_state_preserves_explicitly_stopped_bridge():
+    ecs_client = _FakeEcsClient([])
+    session = _FakeSession(
+        ecs_client=ecs_client,
+        acm_client=object(),
+        ecr_client=object(),
+        secrets_client=_FakeSecretsClient(exists=True),
+    )
+
+    action = _ensure_discord_bridge_state(
+        session,
+        "dr.gamma",
+        "dr-gamma",
+        previous_desired_count=0,
+    )
+
+    assert action is None
+    assert ecs_client.update_calls == []
+
+
+def test_update_stack_restores_running_discord_service(monkeypatch):
+    ecs_client = _FakeEcsClient([])
+    ecs_client.describe_services_response = {
+        "services": [{"serviceName": "cogent-dr-gamma-discord", "desiredCount": 1}]
+    }
+    acm_client = type(
+        "FakeAcm",
+        (),
+        {"list_certificates": lambda self: {"CertificateSummaryList": []}},
+    )()
+    ecr_client = type(
+        "FakeEcr",
+        (),
+        {
+            "describe_repositories": (
+                lambda self, repositoryNames: {
+                    "repositories": [{"repositoryUri": "901289084804.dkr.ecr.us-east-1.amazonaws.com/cogent"}]
+                }
+            )
+        },
+    )()
+    session = _FakeSession(
+        ecs_client=ecs_client,
+        acm_client=acm_client,
+        ecr_client=ecr_client,
+        secrets_client=_FakeSecretsClient(exists=True),
+    )
+
+    monkeypatch.setattr("polis.aws.resolve_org_profile", lambda profile=None: "softmax-org")
+    monkeypatch.setattr("polis.aws.set_profile", lambda profile: None)
+    monkeypatch.setattr("polis.aws.get_polis_session", lambda: (session, "901289084804"))
+
+    class _Result:
+        returncode = 0
+
+    run_calls: list[dict] = []
+
+    def _fake_run(cmd, capture_output, env):
+        run_calls.append({"cmd": cmd, "capture_output": capture_output, "env": env})
+        return _Result()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(update, ["stack"], obj={"cogent_id": "dr.gamma"})
+
+    assert result.exit_code == 0
+    assert run_calls
+    assert ecs_client.update_calls == [
+        {
+            "cluster": "cogent-polis",
+            "service": "cogent-dr-gamma-discord",
+            "desiredCount": 1,
+        }
+    ]
+    assert "Restoring Discord bridge desired count to 1 for cogent-dr.gamma" in result.output
 
 
 def test_update_rds_runs_brain_and_cogos_migrations(monkeypatch):


### PR DESCRIPTION
Problem

Stack deploys could leave a configured Discord bridge stopped because the CDK service definition intentionally keeps `desired_count=0` for unconfigured cogents. We also had separate Discord readiness checks in the dashboard and deploy flows, which made the autostart decision drift from the operator-facing setup view.

Summary

- extract shared Discord secret and ECS service status checks into `cogos.io.discord.setup` and reuse them from the dashboard setup router and brain deploy commands
- preserve a previously running Discord bridge across `brain update stack`
- auto-start the bridge after `brain create` only when schema setup succeeded and a Discord token is already configured
- keep the stack default at `desired_count=0` so fresh stacks without a Discord token do not churn on a missing secret

Testing

- `uv run pytest tests/brain/test_update_cli.py -q`
- `uv run pytest tests/dashboard/test_app.py -q`
- `uv run python - <<'PY'
import brain.cli
import brain.update_cli
import dashboard.routers.setup
print('ok')
PY`
