### PR TITLE
fix(dashboard): fail fast when live DB setup is missing

### DIFF
--- a/src/cli/dashboard.py
+++ b/src/cli/dashboard.py
@@ -10,10 +10,13 @@ import webbrowser
 from pathlib import Path
 
 import click
+from polis.aws import DEFAULT_ORG_PROFILE, ORG_PROFILE_ENV, resolve_org_profile
 
 _COGENT_DIR = Path.home() / ".cogents"
 _REPO_ROOT = Path(__file__).parent.parent.parent
 _FRONTEND_DIR = _REPO_ROOT / "dashboard" / "frontend"
+_PROFILE_HELP = f"AWS profile for DB lookup (default: ${ORG_PROFILE_ENV} or {DEFAULT_ORG_PROFILE})"
+_REQUIRED_DB_ENV = ("DB_RESOURCE_ARN", "DB_SECRET_ARN", "DB_NAME")
 
 
 def _checkout_ports() -> tuple[int, int]:
@@ -66,31 +69,53 @@ def _ensure_frontend_ready() -> None:
     )
 
 
+def _normalize_db_env(env: dict[str, str]) -> dict[str, str]:
+    """Mirror the cluster/resource ARN names used across the repo."""
+    if env.get("DB_CLUSTER_ARN") and not env.get("DB_RESOURCE_ARN"):
+        env["DB_RESOURCE_ARN"] = env["DB_CLUSTER_ARN"]
+    if env.get("DB_RESOURCE_ARN") and not env.get("DB_CLUSTER_ARN"):
+        env["DB_CLUSTER_ARN"] = env["DB_RESOURCE_ARN"]
+    return env
+
+
+def _missing_db_env(env: dict[str, str]) -> list[str]:
+    return [name for name in _REQUIRED_DB_ENV if not env.get(name)]
+
+
 @click.group()
 def dashboard():
     """Dashboard commands."""
     pass
 
 
-def _ensure_db_env(name: str, env: dict, *, assume_polis: bool = False) -> dict:
+def _ensure_db_env(
+    name: str,
+    env: dict[str, str],
+    *,
+    assume_polis: bool = False,
+    profile: str | None = None,
+) -> dict[str, str]:
     """Auto-discover DB ARNs from CloudFormation and add to env dict."""
+    env = _normalize_db_env(env)
     if not assume_polis and env.get("DB_RESOURCE_ARN") and env.get("DB_SECRET_ARN"):
+        env.setdefault("DB_NAME", "cogent")
         return env
 
     safe_name = name.replace(".", "-")
     stack_name = f"cogent-{safe_name}-brain"
+    resolved_profile = resolve_org_profile(profile) if assume_polis else profile
     try:
         if assume_polis:
             from polis.aws import get_polis_session, set_org_profile
 
-            set_org_profile()
+            set_org_profile(profile)
             session, _ = get_polis_session()
             cf = session.client("cloudformation", region_name="us-east-1")
         else:
             import boto3
 
-            session = None
-            cf = boto3.client("cloudformation", region_name="us-east-1")
+            session = boto3.Session(profile_name=profile, region_name="us-east-1") if profile else boto3.Session()
+            cf = session.client("cloudformation", region_name="us-east-1")
         resp = cf.describe_stacks(StackName=stack_name)
         outputs = {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])}
         if "ClusterArn" in outputs:
@@ -115,8 +140,19 @@ def _ensure_db_env(name: str, env: dict, *, assume_polis: bool = False) -> dict:
             env.setdefault("AWS_DEFAULT_REGION", "us-east-1")
             env.setdefault("AWS_REGION", "us-east-1")
     except Exception as e:
+        if assume_polis:
+            raise click.ClickException(
+                "Could not resolve live DB credentials for `--db prod`.\n"
+                f"Cogent: {name}\n"
+                f"Stack: {stack_name}\n"
+                f"AWS profile: {resolved_profile}\n"
+                f"Original error: {e}\n"
+                f"Run `aws sso login --profile {resolved_profile}` or set `{ORG_PROFILE_ENV}` "
+                "to a profile that can assume into polis."
+            ) from e
         click.echo(f"Warning: could not auto-discover DB credentials: {e}")
-    return env
+    env.setdefault("DB_NAME", "cogent")
+    return _normalize_db_env(env)
 
 
 @dashboard.command()
@@ -131,6 +167,7 @@ def _ensure_db_env(name: str, env: dict, *, assume_polis: bool = False) -> dict:
     show_default=True,
     help="DB source: ambient AWS/env (`auto`), local JSON repo (`local`), or polis-assumed live DB (`prod`).",
 )
+@click.option("--profile", default=None, help=_PROFILE_HELP)
 @click.option("--local", is_flag=True, help="Use local DB (USE_LOCAL_DB=1)")
 @click.pass_context
 def serve(
@@ -139,6 +176,7 @@ def serve(
     frontend_port: int | None,
     no_browser: bool,
     db_mode: str,
+    profile: str | None,
     local: bool,
 ):
     """Start the dashboard dev server."""
@@ -165,7 +203,22 @@ def serve(
     if db_mode == "local":
         env["USE_LOCAL_DB"] = "1"
     else:
-        env = _ensure_db_env(name, env, assume_polis=(db_mode == "prod"))
+        env = _ensure_db_env(name, env, assume_polis=(db_mode == "prod"), profile=profile)
+        missing = _missing_db_env(env)
+        if missing:
+            if db_mode == "prod":
+                resolved_profile = resolve_org_profile(profile)
+                raise click.ClickException(
+                    "Dashboard requires live DB credentials but `--db prod` did not resolve them.\n"
+                    f"Missing: {', '.join(missing)}\n"
+                    f"AWS profile: {resolved_profile}\n"
+                    f"Run `aws sso login --profile {resolved_profile}` or set `{ORG_PROFILE_ENV}`."
+                )
+            raise click.ClickException(
+                "Dashboard requires DB credentials for live data.\n"
+                f"Missing: {', '.join(missing)}\n"
+                "Export `DB_RESOURCE_ARN`, `DB_SECRET_ARN`, and `DB_NAME`, or use `--db local`."
+            )
 
     _ensure_frontend_ready()
 

--- a/src/cogos/db/repository.py
+++ b/src/cogos/db/repository.py
@@ -89,7 +89,7 @@ class Repository:
         database: str | None = None,
         region: str | None = None,
     ) -> Repository:
-        resource_arn = resource_arn or os.environ.get("DB_RESOURCE_ARN", "")
+        resource_arn = resource_arn or os.environ.get("DB_RESOURCE_ARN", "") or os.environ.get("DB_CLUSTER_ARN", "")
         secret_arn = secret_arn or os.environ.get("DB_SECRET_ARN", "")
         database = database or os.environ.get("DB_NAME", "")
         region = region or os.environ.get("AWS_REGION", "us-east-1")
@@ -98,7 +98,7 @@ class Repository:
             raise ValueError(
                 "Must provide resource_arn, secret_arn, and database "
                 "via arguments or environment variables "
-                "(DB_RESOURCE_ARN, DB_SECRET_ARN, DB_NAME)"
+                "(DB_RESOURCE_ARN/DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME)"
             )
 
         client = boto3.client("rds-data", region_name=region)

--- a/src/dashboard/db.py
+++ b/src/dashboard/db.py
@@ -1,7 +1,8 @@
 """Singleton Repository for dashboard handlers.
 
-Requires DB_RESOURCE_ARN, DB_SECRET_ARN, and DB_NAME env vars for RDS Data API.
-Set USE_LOCAL_DB=1 to use LocalRepository (JSON file persistence) for local dev.
+Requires DB_RESOURCE_ARN (or DB_CLUSTER_ARN), DB_SECRET_ARN, and DB_NAME env vars
+for RDS Data API. Set USE_LOCAL_DB=1 to use LocalRepository (JSON file
+persistence) for local dev.
 """
 
 from __future__ import annotations

--- a/tests/dashboard/test_cli.py
+++ b/tests/dashboard/test_cli.py
@@ -50,9 +50,12 @@ class _DummyProc:
 def test_serve_db_prod_uses_polis_lookup(tmp_path, monkeypatch):
     calls: dict[str, object] = {}
 
-    def fake_ensure(name: str, env: dict, *, assume_polis: bool = False):
+    def fake_ensure(name: str, env: dict, *, assume_polis: bool = False, profile: str | None = None):
         calls["name"] = name
         calls["assume_polis"] = assume_polis
+        calls["profile"] = profile
+        env["DB_RESOURCE_ARN"] = "cluster-arn"
+        env["DB_SECRET_ARN"] = "secret-arn"
         env["DB_NAME"] = "cogent"
         return env
 
@@ -75,7 +78,7 @@ def test_serve_db_prod_uses_polis_lookup(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 0
-    assert calls == {"name": "dr.gamma", "assume_polis": True}
+    assert calls == {"name": "dr.gamma", "assume_polis": True, "profile": None}
     assert len(procs) == 1
     assert procs[0].env["DASHBOARD_COGENT_NAME"] == "dr.gamma"
 
@@ -101,6 +104,97 @@ def test_serve_db_local_sets_use_local_db(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert len(procs) == 1
     assert procs[0].env["USE_LOCAL_DB"] == "1"
+
+
+def test_serve_db_prod_passes_profile(tmp_path, monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_ensure(name: str, env: dict, *, assume_polis: bool = False, profile: str | None = None):
+        calls["name"] = name
+        calls["assume_polis"] = assume_polis
+        calls["profile"] = profile
+        env["DB_RESOURCE_ARN"] = "cluster-arn"
+        env["DB_SECRET_ARN"] = "secret-arn"
+        env["DB_NAME"] = "cogent"
+        return env
+
+    procs: list[_DummyProc] = []
+
+    def fake_popen(args, env=None, cwd=None):
+        proc = _DummyProc(args, env=env, cwd=cwd)
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr("cli.dashboard._ensure_db_env", fake_ensure)
+    monkeypatch.setattr("cli.dashboard._FRONTEND_DIR", tmp_path / "missing")
+    monkeypatch.setattr("cli.dashboard.subprocess.Popen", fake_popen)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dashboard,
+        ["serve", "--db", "prod", "--profile", "softmax-org", "--no-browser"],
+        obj={"cogent_id": "dr.gamma"},
+    )
+
+    assert result.exit_code == 0
+    assert calls == {"name": "dr.gamma", "assume_polis": True, "profile": "softmax-org"}
+    assert len(procs) == 1
+
+
+def test_serve_db_prod_fails_fast_when_credentials_are_missing(tmp_path, monkeypatch):
+    procs: list[_DummyProc] = []
+
+    def fake_popen(args, env=None, cwd=None):
+        proc = _DummyProc(args, env=env, cwd=cwd)
+        procs.append(proc)
+        return proc
+
+    def fake_ensure(name: str, env: dict, *, assume_polis: bool = False, profile: str | None = None):
+        return env
+
+    monkeypatch.setattr("cli.dashboard._ensure_db_env", fake_ensure)
+    monkeypatch.setattr("cli.dashboard._FRONTEND_DIR", tmp_path / "missing")
+    monkeypatch.setattr("cli.dashboard.subprocess.Popen", fake_popen)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dashboard,
+        ["serve", "--db", "prod", "--no-browser"],
+        obj={"cogent_id": "dr.gamma"},
+    )
+
+    assert result.exit_code != 0
+    assert not procs
+    assert "did not resolve them" in result.output
+    assert "aws sso login --profile softmax-org" in result.output
+
+
+def test_serve_auto_fails_fast_when_live_db_env_is_missing(tmp_path, monkeypatch):
+    procs: list[_DummyProc] = []
+
+    def fake_popen(args, env=None, cwd=None):
+        proc = _DummyProc(args, env=env, cwd=cwd)
+        procs.append(proc)
+        return proc
+
+    def fake_ensure(name: str, env: dict, *, assume_polis: bool = False, profile: str | None = None):
+        return env
+
+    monkeypatch.setattr("cli.dashboard._ensure_db_env", fake_ensure)
+    monkeypatch.setattr("cli.dashboard._FRONTEND_DIR", tmp_path / "missing")
+    monkeypatch.setattr("cli.dashboard.subprocess.Popen", fake_popen)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dashboard,
+        ["serve", "--db", "auto", "--no-browser"],
+        obj={"cogent_id": "dr.gamma"},
+    )
+
+    assert result.exit_code != 0
+    assert not procs
+    assert "Dashboard requires DB credentials for live data." in result.output
+    assert "use `--db local`" in result.output
 
 
 def test_serve_rejects_local_and_db_together(monkeypatch):


### PR DESCRIPTION
Problem

`dashboard serve --db prod` could fail to resolve polis DB credentials, print a warning, and still start the backend and frontend without a usable live database. That turned a credential or setup issue into a partially running dashboard that only exposed the real problem later as 500s. The live dashboard path also treated `DB_RESOURCE_ARN` and `DB_CLUSTER_ARN` inconsistently.

Summary

- add a `--profile` option to `dashboard serve` and thread it through live DB lookup
- fail fast for `--db prod` and live `--db auto` runs when required DB env vars are still missing instead of starting a broken dashboard
- normalize `DB_RESOURCE_ARN` and `DB_CLUSTER_ARN` so either env name works for live dashboard repository creation
- add CLI tests covering prod profile selection and the new fail-fast behavior

Testing

- `uv run --with pytest python -m pytest tests/dashboard/test_cli.py`
- `uv run python -m compileall src/cli/dashboard.py src/cogos/db/repository.py src/dashboard/db.py`