### PR TITLE
Align local execution with prod dispatch semantics

### DIFF
--- a/src/cogos/cli/__main__.py
+++ b/src/cogos/cli/__main__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from pathlib import Path
 from uuid import UUID
 
@@ -74,11 +73,9 @@ def _ensure_db_env(cogent_name: str) -> None:
 
 
 def _repo():
-    if os.environ.get("USE_LOCAL_DB") == "1":
-        from cogos.db.local_repository import LocalRepository
-        return LocalRepository()
-    from cogos.db.repository import Repository
-    return Repository.create()
+    from cogos.db.factory import create_repository
+
+    return create_repository()
 
 
 def _bedrock_client():

--- a/src/cogos/db/factory.py
+++ b/src/cogos/db/factory.py
@@ -1,0 +1,29 @@
+"""Repository selection helpers for local and remote CogOS runtimes."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def create_repository(
+    *,
+    resource_arn: str | None = None,
+    secret_arn: str | None = None,
+    database: str | None = None,
+    region: str | None = None,
+) -> Any:
+    """Create the active repository implementation for the current environment."""
+    if os.environ.get("USE_LOCAL_DB") == "1":
+        from cogos.db.local_repository import LocalRepository
+
+        return LocalRepository()
+
+    from cogos.db.repository import Repository
+
+    return Repository.create(
+        resource_arn=resource_arn,
+        secret_arn=secret_arn,
+        database=database,
+        region=region,
+    )

--- a/src/cogos/db/local_repository.py
+++ b/src/cogos/db/local_repository.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+import fcntl
 import json
 import logging
 import os
@@ -15,7 +17,6 @@ from cogos.db.models import (
     Capability,
     Channel,
     ChannelMessage,
-    ChannelType,
     Cron,
     Delivery,
     DeliveryStatus,
@@ -26,7 +27,6 @@ from cogos.db.models import (
     ProcessCapability,
     ProcessStatus,
     Resource,
-    ResourceType,
     Run,
     RunStatus,
     Schema,
@@ -56,7 +56,9 @@ class LocalRepository:
         self._data_dir = Path(data_dir)
         self._data_dir.mkdir(parents=True, exist_ok=True)
         self._file = self._data_dir / "cogos_data.json"
+        self._lock_file = self._data_dir / "cogos_data.lock"
         self._file_mtime: float = 0.0
+        self._write_depth = 0
         self._processes: dict[UUID, Process] = {}
         self._capabilities: dict[UUID, Capability] = {}
         self._handlers: dict[UUID, Handler] = {}
@@ -76,26 +78,7 @@ class LocalRepository:
 
     # ── Persistence ──────────────────────────────────────────
 
-    def _maybe_reload(self) -> None:
-        if not self._file.exists():
-            return
-        try:
-            mtime = self._file.stat().st_mtime
-        except OSError:
-            return
-        if mtime > self._file_mtime:
-            self._load()
-
-    def _load(self) -> None:
-        if not self._file.exists():
-            return
-        try:
-            self._file_mtime = self._file.stat().st_mtime
-            data = json.loads(self._file.read_text())
-        except (json.JSONDecodeError, OSError):
-            logger.warning("Could not load cogos data from %s", self._file)
-            return
-
+    def _reset_state(self) -> None:
         self._processes.clear()
         self._capabilities.clear()
         self._handlers.clear()
@@ -111,55 +94,17 @@ class LocalRepository:
         self._channel_messages.clear()
         self._meta.clear()
 
-        for p in data.get("processes", []):
-            proc = Process(**p)
-            self._processes[proc.id] = proc
-        for c in data.get("capabilities", []):
-            cap = Capability(**c)
-            self._capabilities[cap.id] = cap
-        for h in data.get("handlers", []):
-            handler = Handler(**h)
-            self._handlers[handler.id] = handler
-        for pc in data.get("process_capabilities", []):
-            pcap = ProcessCapability(**pc)
-            self._process_capabilities[pcap.id] = pcap
-        for res in data.get("resources", []):
-            r = Resource(**res)
-            self._resources[r.name] = r
-        for cr in data.get("cron_rules", []):
-            c = Cron(**cr)
-            self._cron_rules[c.id] = c
-        for f in data.get("files", []):
-            fi = File(**f)
-            self._files[fi.id] = fi
-        for fv in data.get("file_versions", []):
-            ver = FileVersion(**fv)
-            self._file_versions.setdefault(ver.file_id, []).append(ver)
-        for ed in data.get("deliveries", data.get("event_deliveries", [])):
-            delivery = Delivery(**ed)
-            self._deliveries[delivery.id] = delivery
-        for r in data.get("runs", []):
-            run = Run(**r)
-            self._runs[run.id] = run
-        for s in data.get("schemas", []):
-            schema = Schema(**s)
-            self._schemas[schema.id] = schema
-        for ch in data.get("channels", []):
-            channel = Channel(**ch)
-            self._channels[channel.id] = channel
-        for cm in data.get("channel_messages", []):
-            msg = ChannelMessage(**cm)
-            self._channel_messages[msg.id] = msg
-        self._meta.update(data.get("meta", {}))
+    def _read_persisted_data(self) -> dict[str, Any]:
+        if not self._file.exists():
+            return {}
+        try:
+            return json.loads(self._file.read_text())
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Could not load cogos data from %s", self._file)
+            return {}
 
-        logger.info(
-            "Loaded cogos data: %d processes, %d capabilities, %d files, %d deliveries, %d runs",
-            len(self._processes), len(self._capabilities), len(self._files),
-            len(self._deliveries), len(self._runs),
-        )
-
-    def _save(self) -> None:
-        data = {
+    def _serialize_state(self) -> dict[str, Any]:
+        return {
             "processes": [p.model_dump(mode="json") for p in self._processes.values()],
             "capabilities": [c.model_dump(mode="json") for c in self._capabilities.values()],
             "handlers": [h.model_dump(mode="json") for h in self._handlers.values()],
@@ -179,8 +124,179 @@ class LocalRepository:
             "channel_messages": [m.model_dump(mode="json") for m in self._channel_messages.values()],
             "meta": self._meta,
         }
-        self._file.write_text(json.dumps(data, indent=2, default=_json_serial))
+
+    @staticmethod
+    def _row_key(row: dict[str, Any], *fields: str) -> Any:
+        if len(fields) == 1:
+            return row.get(fields[0])
+        return tuple(row.get(field) for field in fields)
+
+    @classmethod
+    def _merge_rows(
+        cls,
+        latest_rows: list[dict[str, Any]],
+        current_rows: list[dict[str, Any]],
+        *,
+        primary_fields: tuple[str, ...],
+        conflict_fields: tuple[str, ...] | None = None,
+    ) -> list[dict[str, Any]]:
+        merged = {
+            cls._row_key(row, *primary_fields): row
+            for row in latest_rows
+        }
+        conflicts = {}
+        if conflict_fields:
+            conflicts = {
+                cls._row_key(row, *conflict_fields): cls._row_key(row, *primary_fields)
+                for row in latest_rows
+            }
+
+        for row in current_rows:
+            primary_key = cls._row_key(row, *primary_fields)
+            if conflict_fields:
+                conflict_key = cls._row_key(row, *conflict_fields)
+                previous_primary = conflicts.get(conflict_key)
+                if previous_primary is not None and previous_primary != primary_key:
+                    merged.pop(previous_primary, None)
+                conflicts[conflict_key] = primary_key
+            merged[primary_key] = row
+
+        return list(merged.values())
+
+    @classmethod
+    def _merge_serialized_data(
+        cls,
+        latest_data: dict[str, Any],
+        current_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        specs: dict[str, tuple[tuple[str, ...], tuple[str, ...] | None]] = {
+            "processes": (("id",), ("name",)),
+            "capabilities": (("id",), ("name",)),
+            "handlers": (("id",), ("process", "channel")),
+            "process_capabilities": (("id",), ("process", "name")),
+            "files": (("id",), ("key",)),
+            "file_versions": (("id",), ("file_id", "version")),
+            "resources": (("id",), ("name",)),
+            "cron_rules": (("id",), ("expression", "channel_name")),
+            "deliveries": (("id",), ("message", "handler")),
+            "runs": (("id",), None),
+            "schemas": (("id",), ("name",)),
+            "channels": (("id",), ("name",)),
+            "channel_messages": (("id",), None),
+        }
+
+        merged = {}
+        for key, (primary_fields, conflict_fields) in specs.items():
+            merged[key] = cls._merge_rows(
+                latest_data.get(key, []),
+                current_data.get(key, []),
+                primary_fields=primary_fields,
+                conflict_fields=conflict_fields,
+            )
+
+        merged["meta"] = dict(latest_data.get("meta", {}))
+        merged["meta"].update(current_data.get("meta", {}))
+        return merged
+
+    def _populate_from_data(self, data: dict[str, Any]) -> None:
+        self._reset_state()
+
+        for p in data.get("processes", []):
+            proc = Process(**p)
+            self._processes[proc.id] = proc
+        for c in data.get("capabilities", []):
+            cap = Capability(**c)
+            self._capabilities[cap.id] = cap
+        for h in data.get("handlers", []):
+            handler = Handler(**h)
+            self._handlers[handler.id] = handler
+        for pc in data.get("process_capabilities", []):
+            pcap = ProcessCapability(**pc)
+            self._process_capabilities[pcap.id] = pcap
+        for res in data.get("resources", []):
+            resource = Resource(**res)
+            self._resources[resource.name] = resource
+        for cr in data.get("cron_rules", []):
+            cron = Cron(**cr)
+            self._cron_rules[cron.id] = cron
+        for f in data.get("files", []):
+            file = File(**f)
+            self._files[file.id] = file
+        for fv in data.get("file_versions", []):
+            version = FileVersion(**fv)
+            self._file_versions.setdefault(version.file_id, []).append(version)
+        for ed in data.get("deliveries", data.get("event_deliveries", [])):
+            delivery = Delivery(**ed)
+            self._deliveries[delivery.id] = delivery
+        for r in data.get("runs", []):
+            run = Run(**r)
+            self._runs[run.id] = run
+        for s in data.get("schemas", []):
+            schema = Schema(**s)
+            self._schemas[schema.id] = schema
+        for ch in data.get("channels", []):
+            channel = Channel(**ch)
+            self._channels[channel.id] = channel
+        for cm in data.get("channel_messages", []):
+            message = ChannelMessage(**cm)
+            self._channel_messages[message.id] = message
+        self._meta.update(data.get("meta", {}))
+
+    @contextmanager
+    def _writing(self):
+        outermost = self._write_depth == 0
+        if outermost:
+            self._maybe_reload()
+        self._write_depth += 1
+        committed = False
+        try:
+            yield
+            committed = True
+        finally:
+            self._write_depth -= 1
+            if outermost and committed:
+                self._save()
+
+    def _maybe_reload(self) -> None:
+        if self._write_depth > 0:
+            return
+        if not self._file.exists():
+            return
+        try:
+            mtime = self._file.stat().st_mtime
+        except OSError:
+            return
+        if mtime > self._file_mtime:
+            self._load()
+
+    def _load(self) -> None:
+        if not self._file.exists():
+            return
         self._file_mtime = self._file.stat().st_mtime
+        data = self._read_persisted_data()
+        self._populate_from_data(data)
+
+        logger.info(
+            "Loaded cogos data: %d processes, %d capabilities, %d files, %d deliveries, %d runs",
+            len(self._processes), len(self._capabilities), len(self._files),
+            len(self._deliveries), len(self._runs),
+        )
+
+    def _save(self) -> None:
+        current_data = self._serialize_state()
+        self._lock_file.touch(exist_ok=True)
+        with self._lock_file.open("a+") as lock_handle:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            try:
+                latest_data = self._read_persisted_data()
+                merged = self._merge_serialized_data(latest_data, current_data)
+                tmp_file = self._data_dir / f".{self._file.name}.{os.getpid()}.tmp"
+                tmp_file.write_text(json.dumps(merged, indent=2, default=_json_serial))
+                tmp_file.replace(self._file)
+                self._file_mtime = self._file.stat().st_mtime
+                self._populate_from_data(merged)
+            finally:
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
 
     # ── Raw query stubs (used by cogos_events router) ────────
 
@@ -192,21 +308,8 @@ class LocalRepository:
 
     def clear_all(self) -> None:
         """Wipe all in-memory data and persist the empty state."""
-        self._processes.clear()
-        self._capabilities.clear()
-        self._handlers.clear()
-        self._files.clear()
-        self._file_versions.clear()
-        self._process_capabilities.clear()
-        self._resources.clear()
-        self._cron_rules.clear()
-        self._deliveries.clear()
-        self._runs.clear()
-        self._schemas.clear()
-        self._channels.clear()
-        self._channel_messages.clear()
-        self._meta.clear()
-        self._save()
+        with self._writing():
+            self._reset_state()
 
     @staticmethod
     def _json_field(row: dict, key: str, default: Any = None) -> Any:
@@ -223,23 +326,23 @@ class LocalRepository:
     # ── Processes ─────────────────────────────────────────────
 
     def upsert_process(self, p: Process) -> UUID:
-        now = datetime.utcnow()
-        existing = self._processes.get(p.id)
-        if existing is None:
-            # Check by name
-            for ep in self._processes.values():
-                if ep.name == p.name:
-                    existing = ep
-                    break
-        if existing:
-            p.id = existing.id
-            p.created_at = existing.created_at
-        else:
-            p.created_at = now
-        p.updated_at = now
-        self._processes[p.id] = p
-        self._save()
-        return p.id
+        with self._writing():
+            now = datetime.utcnow()
+            existing = self._processes.get(p.id)
+            if existing is None:
+                # Check by name
+                for ep in self._processes.values():
+                    if ep.name == p.name:
+                        existing = ep
+                        break
+            if existing:
+                p.id = existing.id
+                p.created_at = existing.created_at
+            else:
+                p.created_at = now
+            p.updated_at = now
+            self._processes[p.id] = p
+            return p.id
 
     def get_process(self, process_id: UUID) -> Process | None:
         self._maybe_reload()
@@ -253,11 +356,11 @@ class LocalRepository:
         return None
 
     def delete_process(self, process_id: UUID) -> bool:
-        if process_id in self._processes:
-            del self._processes[process_id]
-            self._save()
-            return True
-        return False
+        with self._writing():
+            if process_id in self._processes:
+                del self._processes[process_id]
+                return True
+            return False
 
     def list_processes(self, *, status: ProcessStatus | None = None, limit: int = 200) -> list[Process]:
         self._maybe_reload()
@@ -268,17 +371,17 @@ class LocalRepository:
         return procs[:limit]
 
     def update_process_status(self, process_id: UUID, status: ProcessStatus) -> bool:
-        process = self._processes.get(process_id)
-        if process is None:
-            return False
-        process.status = status
-        if status == ProcessStatus.RUNNABLE:
-            process.runnable_since = process.runnable_since or datetime.utcnow()
-        else:
-            process.runnable_since = None
-        process.updated_at = datetime.utcnow()
-        self._save()
-        return True
+        with self._writing():
+            process = self._processes.get(process_id)
+            if process is None:
+                return False
+            process.status = status
+            if status == ProcessStatus.RUNNABLE:
+                process.runnable_since = process.runnable_since or datetime.utcnow()
+            else:
+                process.runnable_since = None
+            process.updated_at = datetime.utcnow()
+            return True
 
     def get_runnable_processes(self, limit: int = 50) -> list[Process]:
         self._maybe_reload()
@@ -293,33 +396,33 @@ class LocalRepository:
         return runnable[:limit]
 
     def increment_retry(self, process_id: UUID) -> bool:
-        process = self._processes.get(process_id)
-        if process is None:
-            return False
-        process.retry_count += 1
-        process.updated_at = datetime.utcnow()
-        self._save()
-        return True
+        with self._writing():
+            process = self._processes.get(process_id)
+            if process is None:
+                return False
+            process.retry_count += 1
+            process.updated_at = datetime.utcnow()
+            return True
 
     # ── Capabilities ─────────────────────────────────────────
 
     def upsert_capability(self, cap: Capability) -> UUID:
-        now = datetime.utcnow()
-        existing = self._capabilities.get(cap.id)
-        if existing is None:
-            for ec in self._capabilities.values():
-                if ec.name == cap.name:
-                    existing = ec
-                    break
-        if existing:
-            cap.id = existing.id
-            cap.created_at = existing.created_at
-        else:
-            cap.created_at = now
-        cap.updated_at = now
-        self._capabilities[cap.id] = cap
-        self._save()
-        return cap.id
+        with self._writing():
+            now = datetime.utcnow()
+            existing = self._capabilities.get(cap.id)
+            if existing is None:
+                for ec in self._capabilities.values():
+                    if ec.name == cap.name:
+                        existing = ec
+                        break
+            if existing:
+                cap.id = existing.id
+                cap.created_at = existing.created_at
+            else:
+                cap.created_at = now
+            cap.updated_at = now
+            self._capabilities[cap.id] = cap
+            return cap.id
 
     def get_capability_by_name(self, name: str) -> Capability | None:
         self._maybe_reload()
@@ -354,17 +457,16 @@ class LocalRepository:
     # ── Handlers ─────────────────────────────────────────────
 
     def create_handler(self, h: Handler) -> UUID:
-        # Upsert by (process, channel)
-        for existing in self._handlers.values():
-            if h.channel is not None:
-                if existing.process == h.process and existing.channel == h.channel:
-                    existing.enabled = h.enabled
-                    self._save()
-                    return existing.id
-        h.created_at = datetime.utcnow()
-        self._handlers[h.id] = h
-        self._save()
-        return h.id
+        with self._writing():
+            # Upsert by (process, channel)
+            for existing in self._handlers.values():
+                if h.channel is not None:
+                    if existing.process == h.process and existing.channel == h.channel:
+                        existing.enabled = h.enabled
+                        return existing.id
+            h.created_at = datetime.utcnow()
+            self._handlers[h.id] = h
+            return h.id
 
     def list_handlers(self, *, process_id: UUID | None = None, enabled_only: bool = False) -> list[Handler]:
         self._maybe_reload()
@@ -377,11 +479,11 @@ class LocalRepository:
         return handlers
 
     def delete_handler(self, handler_id: UUID) -> bool:
-        if handler_id in self._handlers:
-            del self._handlers[handler_id]
-            self._save()
-            return True
-        return False
+        with self._writing():
+            if handler_id in self._handlers:
+                del self._handlers[handler_id]
+                return True
+            return False
 
     def match_handlers(self, event_type: str) -> list[Handler]:
         """Legacy stub -- returns empty list since event_pattern matching is removed."""
@@ -391,22 +493,21 @@ class LocalRepository:
 
     def create_process_capability(self, pc: ProcessCapability) -> UUID:
         """Upsert a process-capability binding by (process, name) pair."""
-        for existing in self._process_capabilities.values():
-            if existing.process == pc.process and existing.name == pc.name:
-                existing.capability = pc.capability
-                existing.config = pc.config
-                self._save()
-                return existing.id
-        self._process_capabilities[pc.id] = pc
-        self._save()
-        return pc.id
+        with self._writing():
+            for existing in self._process_capabilities.values():
+                if existing.process == pc.process and existing.name == pc.name:
+                    existing.capability = pc.capability
+                    existing.config = pc.config
+                    return existing.id
+            self._process_capabilities[pc.id] = pc
+            return pc.id
 
     def delete_process_capability(self, pc_id: UUID) -> bool:
-        if pc_id in self._process_capabilities:
-            del self._process_capabilities[pc_id]
-            self._save()
-            return True
-        return False
+        with self._writing():
+            if pc_id in self._process_capabilities:
+                del self._process_capabilities[pc_id]
+                return True
+            return False
 
     def list_process_capabilities(self, process_id: UUID) -> list[ProcessCapability]:
         self._maybe_reload()
@@ -437,12 +538,12 @@ class LocalRepository:
     # ── Files ────────────────────────────────────────────────
 
     def insert_file(self, f: File) -> UUID:
-        now = datetime.utcnow()
-        f.created_at = now
-        f.updated_at = now
-        self._files[f.id] = f
-        self._save()
-        return f.id
+        with self._writing():
+            now = datetime.utcnow()
+            f.created_at = now
+            f.updated_at = now
+            self._files[f.id] = f
+            return f.id
 
     def get_file_by_key(self, key: str) -> File | None:
         self._maybe_reload()
@@ -464,19 +565,19 @@ class LocalRepository:
         return files[:limit]
 
     def delete_file(self, file_id: UUID) -> bool:
-        if file_id in self._files:
-            del self._files[file_id]
-            self._file_versions.pop(file_id, None)
-            self._save()
-            return True
-        return False
+        with self._writing():
+            if file_id in self._files:
+                del self._files[file_id]
+                self._file_versions.pop(file_id, None)
+                return True
+            return False
 
     def insert_file_version(self, fv: FileVersion) -> None:
-        fv.created_at = datetime.utcnow()
-        self._file_versions.setdefault(fv.file_id, []).append(fv)
-        if fv.file_id in self._files:
-            self._files[fv.file_id].updated_at = datetime.utcnow()
-        self._save()
+        with self._writing():
+            fv.created_at = datetime.utcnow()
+            self._file_versions.setdefault(fv.file_id, []).append(fv)
+            if fv.file_id in self._files:
+                self._files[fv.file_id].updated_at = datetime.utcnow()
 
     def get_active_file_version(self, file_id: UUID) -> FileVersion | None:
         versions = self._file_versions.get(file_id, [])
@@ -493,40 +594,40 @@ class LocalRepository:
         return versions
 
     def set_active_file_version(self, file_id: UUID, version: int) -> None:
-        for fv in self._file_versions.get(file_id, []):
-            fv.is_active = fv.version == version
-        self._save()
+        with self._writing():
+            for fv in self._file_versions.get(file_id, []):
+                fv.is_active = fv.version == version
 
     def delete_file_version(self, file_id: UUID, version: int) -> bool:
-        versions = self._file_versions.get(file_id, [])
-        before = len(versions)
-        self._file_versions[file_id] = [v for v in versions if v.version != version]
-        if len(self._file_versions[file_id]) < before:
-            self._save()
-            return True
-        return False
+        with self._writing():
+            versions = self._file_versions.get(file_id, [])
+            before = len(versions)
+            self._file_versions[file_id] = [v for v in versions if v.version != version]
+            if len(self._file_versions[file_id]) < before:
+                return True
+            return False
 
     def update_file_version_content(self, file_id: UUID, version: int, content: str) -> bool:
-        for fv in self._file_versions.get(file_id, []):
-            if fv.version == version:
-                fv.content = content
-                self._save()
-                return True
-        return False
+        with self._writing():
+            for fv in self._file_versions.get(file_id, []):
+                if fv.version == version:
+                    fv.content = content
+                    return True
+            return False
 
     # ── Resources ─────────────────────────────────────────────
 
     def upsert_resource(self, r: Resource) -> str:
-        now = datetime.utcnow()
-        existing = self._resources.get(r.name)
-        if existing:
-            r.id = existing.id
-            r.created_at = existing.created_at
-        else:
-            r.created_at = now
-        self._resources[r.name] = r
-        self._save()
-        return r.name
+        with self._writing():
+            now = datetime.utcnow()
+            existing = self._resources.get(r.name)
+            if existing:
+                r.id = existing.id
+                r.created_at = existing.created_at
+            else:
+                r.created_at = now
+            self._resources[r.name] = r
+            return r.name
 
     def list_resources(self) -> list[Resource]:
         self._maybe_reload()
@@ -537,21 +638,21 @@ class LocalRepository:
     # ── Cron Rules ────────────────────────────────────────────
 
     def upsert_cron(self, c: Cron) -> UUID:
-        now = datetime.utcnow()
-        # Match by (expression, channel_name)
-        existing = None
-        for ec in self._cron_rules.values():
-            if ec.expression == c.expression and ec.channel_name == c.channel_name:
-                existing = ec
-                break
-        if existing:
-            c.id = existing.id
-            c.created_at = existing.created_at
-        else:
-            c.created_at = now
-        self._cron_rules[c.id] = c
-        self._save()
-        return c.id
+        with self._writing():
+            now = datetime.utcnow()
+            # Match by (expression, channel_name)
+            existing = None
+            for ec in self._cron_rules.values():
+                if ec.expression == c.expression and ec.channel_name == c.channel_name:
+                    existing = ec
+                    break
+            if existing:
+                c.id = existing.id
+                c.created_at = existing.created_at
+            else:
+                c.created_at = now
+            self._cron_rules[c.id] = c
+            return c.id
 
     def list_cron_rules(self, *, enabled_only: bool = False) -> list[Cron]:
         self._maybe_reload()
@@ -564,14 +665,13 @@ class LocalRepository:
     # ── Deliveries ───────────────────────────────────────────
 
     def create_delivery(self, ed: Delivery) -> tuple[UUID, bool]:
-        self._maybe_reload()
-        for existing in self._deliveries.values():
-            if existing.message == ed.message and existing.handler == ed.handler:
-                return existing.id, False
-        ed.created_at = datetime.utcnow()
-        self._deliveries[ed.id] = ed
-        self._save()
-        return ed.id, True
+        with self._writing():
+            for existing in self._deliveries.values():
+                if existing.message == ed.message and existing.handler == ed.handler:
+                    return existing.id, False
+            ed.created_at = datetime.utcnow()
+            self._deliveries[ed.id] = ed
+            return ed.id, True
 
     def get_pending_deliveries(self, process_id: UUID) -> list[Delivery]:
         self._maybe_reload()
@@ -587,41 +687,40 @@ class LocalRepository:
         return bool(self.get_pending_deliveries(process_id))
 
     def mark_delivered(self, delivery_id: UUID, run_id: UUID) -> bool:
-        delivery = self._deliveries.get(delivery_id)
-        if delivery is None:
-            return False
-        delivery.status = DeliveryStatus.DELIVERED
-        delivery.run = run_id
-        self._save()
-        return True
+        with self._writing():
+            delivery = self._deliveries.get(delivery_id)
+            if delivery is None:
+                return False
+            delivery.status = DeliveryStatus.DELIVERED
+            delivery.run = run_id
+            return True
 
     def mark_queued(self, delivery_id: UUID, run_id: UUID) -> bool:
-        delivery = self._deliveries.get(delivery_id)
-        if delivery is None:
-            return False
-        delivery.status = DeliveryStatus.QUEUED
-        delivery.run = run_id
-        self._save()
-        return True
+        with self._writing():
+            delivery = self._deliveries.get(delivery_id)
+            if delivery is None:
+                return False
+            delivery.status = DeliveryStatus.QUEUED
+            delivery.run = run_id
+            return True
 
     def requeue_delivery(self, delivery_id: UUID) -> bool:
-        delivery = self._deliveries.get(delivery_id)
-        if delivery is None:
-            return False
-        delivery.status = DeliveryStatus.PENDING
-        delivery.run = None
-        self._save()
-        return True
+        with self._writing():
+            delivery = self._deliveries.get(delivery_id)
+            if delivery is None:
+                return False
+            delivery.status = DeliveryStatus.PENDING
+            delivery.run = None
+            return True
 
     def mark_run_deliveries_delivered(self, run_id: UUID) -> int:
-        updated = 0
-        for delivery in self._deliveries.values():
-            if delivery.run == run_id and delivery.status == DeliveryStatus.QUEUED:
-                delivery.status = DeliveryStatus.DELIVERED
-                updated += 1
-        if updated:
-            self._save()
-        return updated
+        with self._writing():
+            updated = 0
+            for delivery in self._deliveries.values():
+                if delivery.run == run_id and delivery.status == DeliveryStatus.QUEUED:
+                    delivery.status = DeliveryStatus.DELIVERED
+                    updated += 1
+            return updated
 
     def rollback_dispatch(
         self,
@@ -631,20 +730,21 @@ class LocalRepository:
         *,
         error: str | None = None,
     ) -> None:
-        if delivery_id is not None:
-            self.requeue_delivery(delivery_id)
-        self.complete_run(run_id, status=RunStatus.FAILED, error=(error or "executor invoke failed")[:4000])
-        current = self._processes.get(process_id)
-        if current and current.status not in (ProcessStatus.DISABLED, ProcessStatus.SUSPENDED):
-            self.update_process_status(process_id, ProcessStatus.RUNNABLE)
+        with self._writing():
+            if delivery_id is not None:
+                self.requeue_delivery(delivery_id)
+            self.complete_run(run_id, status=RunStatus.FAILED, error=(error or "executor invoke failed")[:4000])
+            current = self._processes.get(process_id)
+            if current and current.status not in (ProcessStatus.DISABLED, ProcessStatus.SUSPENDED):
+                self.update_process_status(process_id, ProcessStatus.RUNNABLE)
 
     # ── Runs ─────────────────────────────────────────────────
 
     def create_run(self, run: Run) -> UUID:
-        run.created_at = datetime.utcnow()
-        self._runs[run.id] = run
-        self._save()
-        return run.id
+        with self._writing():
+            run.created_at = datetime.utcnow()
+            self._runs[run.id] = run
+            return run.id
 
     def complete_run(
         self,
@@ -659,22 +759,22 @@ class LocalRepository:
         result: dict | None = None,
         scope_log: list[dict] | None = None,
     ) -> bool:
-        run = self._runs.get(run_id)
-        if run is None:
-            return False
-        run.status = status
-        run.tokens_in = tokens_in
-        run.tokens_out = tokens_out
-        run.cost_usd = cost_usd
-        run.duration_ms = duration_ms
-        run.error = error
-        if result is not None:
-            run.result = result
-        if scope_log is not None:
-            run.scope_log = scope_log
-        run.completed_at = datetime.utcnow()
-        self._save()
-        return True
+        with self._writing():
+            run = self._runs.get(run_id)
+            if run is None:
+                return False
+            run.status = status
+            run.tokens_in = tokens_in
+            run.tokens_out = tokens_out
+            run.cost_usd = cost_usd
+            run.duration_ms = duration_ms
+            run.error = error
+            if result is not None:
+                run.result = result
+            if scope_log is not None:
+                run.scope_log = scope_log
+            run.completed_at = datetime.utcnow()
+            return True
 
     def get_run(self, run_id: UUID) -> Run | None:
         self._maybe_reload()
@@ -691,12 +791,12 @@ class LocalRepository:
     # ── Meta ────────────────────────────────────────────────
 
     def set_meta(self, key: str, value: str = "") -> None:
-        self._meta[key] = {
-            "key": key,
-            "value": value,
-            "updated_at": datetime.utcnow().isoformat(),
-        }
-        self._save()
+        with self._writing():
+            self._meta[key] = {
+                "key": key,
+                "value": value,
+                "updated_at": datetime.utcnow().isoformat(),
+            }
 
     def get_meta(self, key: str) -> dict[str, str] | None:
         self._maybe_reload()
@@ -705,16 +805,16 @@ class LocalRepository:
     # ── Schema CRUD ──────────────────────────────────────────
 
     def upsert_schema(self, s: Schema) -> UUID:
-        for existing in self._schemas.values():
-            if existing.name == s.name:
-                s.id = existing.id
-                s.created_at = existing.created_at
-                break
-        if s.created_at is None:
-            s.created_at = datetime.utcnow()
-        self._schemas[s.id] = s
-        self._save()
-        return s.id
+        with self._writing():
+            for existing in self._schemas.values():
+                if existing.name == s.name:
+                    s.id = existing.id
+                    s.created_at = existing.created_at
+                    break
+            if s.created_at is None:
+                s.created_at = datetime.utcnow()
+            self._schemas[s.id] = s
+            return s.id
 
     def get_schema(self, schema_id: UUID) -> Schema | None:
         self._maybe_reload()
@@ -734,16 +834,16 @@ class LocalRepository:
     # ── Channel CRUD ─────────────────────────────────────────
 
     def upsert_channel(self, ch: Channel) -> UUID:
-        for existing in self._channels.values():
-            if existing.name == ch.name:
-                ch.id = existing.id
-                ch.created_at = existing.created_at
-                break
-        if ch.created_at is None:
-            ch.created_at = datetime.utcnow()
-        self._channels[ch.id] = ch
-        self._save()
-        return ch.id
+        with self._writing():
+            for existing in self._channels.values():
+                if existing.name == ch.name:
+                    ch.id = existing.id
+                    ch.created_at = existing.created_at
+                    break
+            if ch.created_at is None:
+                ch.created_at = datetime.utcnow()
+            self._channels[ch.id] = ch
+            return ch.id
 
     def get_channel(self, channel_id: UUID) -> Channel | None:
         self._maybe_reload()
@@ -764,33 +864,32 @@ class LocalRepository:
         return sorted(channels, key=lambda ch: ch.name)
 
     def close_channel(self, channel_id: UUID) -> bool:
-        self._maybe_reload()
-        ch = self._channels.get(channel_id)
-        if ch is None:
-            return False
-        ch.closed_at = datetime.utcnow()
-        self._save()
-        return True
+        with self._writing():
+            ch = self._channels.get(channel_id)
+            if ch is None:
+                return False
+            ch.closed_at = datetime.utcnow()
+            return True
 
     # ── Channel Message CRUD ─────────────────────────────────
 
     def append_channel_message(self, msg: ChannelMessage) -> UUID:
-        if msg.created_at is None:
-            msg.created_at = datetime.utcnow()
-        self._channel_messages[msg.id] = msg
+        with self._writing():
+            if msg.created_at is None:
+                msg.created_at = datetime.utcnow()
+            self._channel_messages[msg.id] = msg
 
-        # Auto-create deliveries for handlers bound to this channel
-        handlers = self.match_handlers_by_channel(msg.channel)
-        for handler in handlers:
-            delivery = Delivery(message=msg.id, handler=handler.id)
-            _delivery_id, inserted = self.create_delivery(delivery)
-            if inserted:
-                proc = self.get_process(handler.process)
-                if proc and proc.status == ProcessStatus.WAITING:
-                    self.update_process_status(handler.process, ProcessStatus.RUNNABLE)
+            # Auto-create deliveries for handlers bound to this channel
+            handlers = self.match_handlers_by_channel(msg.channel)
+            for handler in handlers:
+                delivery = Delivery(message=msg.id, handler=handler.id)
+                _delivery_id, inserted = self.create_delivery(delivery)
+                if inserted:
+                    proc = self.get_process(handler.process)
+                    if proc and proc.status == ProcessStatus.WAITING:
+                        self.update_process_status(handler.process, ProcessStatus.RUNNABLE)
 
-        self._save()
-        return msg.id
+            return msg.id
 
     def list_channel_messages(self, channel_id: UUID, *, limit: int = 100) -> list[ChannelMessage]:
         self._maybe_reload()

--- a/src/cogos/executor/handler.py
+++ b/src/cogos/executor/handler.py
@@ -9,13 +9,13 @@ import re
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from decimal import Decimal
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
 import boto3
 
+from cogos.db.factory import create_repository
 from cogos.db.models import Process, ProcessStatus, Run, RunStatus
 from cogos.db.models.channel_message import ChannelMessage
 from cogos.db.repository import Repository
@@ -47,7 +47,7 @@ def get_config() -> ExecutorConfig:
 
 def get_repo(config: ExecutorConfig | None = None) -> Repository:
     config = config or get_config()
-    return Repository.create(
+    return create_repository(
         resource_arn=config.db_cluster_arn,
         secret_arn=config.db_secret_arn,
         database=config.db_name,

--- a/src/cogos/image/apply.py
+++ b/src/cogos/image/apply.py
@@ -62,9 +62,12 @@ def apply_image(spec: ImageSpec, repo, *, clean: bool = False) -> dict[str, int]
     # 3. Cron rules (skip if no table/method yet)
     if hasattr(repo, "upsert_cron"):
         for cron_dict in spec.cron_rules:
+            channel_name = cron_dict.get("channel_name") or cron_dict.get("event_type")
+            if not channel_name:
+                raise ValueError("cron rule missing channel_name")
             c = Cron(
                 expression=cron_dict["expression"],
-                event_type=cron_dict["event_type"],
+                channel_name=channel_name,
                 payload=cron_dict.get("payload") or {},
                 enabled=cron_dict.get("enabled", True),
             )

--- a/src/cogos/image/snapshot.py
+++ b/src/cogos/image/snapshot.py
@@ -165,7 +165,7 @@ def snapshot_image(repo, output_dir: Path, *, cogent_name: str | None = None) ->
             parts.append(f'    schema={_repr_val(schema_name)}')
         parts.append(f'    channel_type={_repr_val(ch.channel_type.value)}')
         if ch.auto_close:
-            parts.append(f'    auto_close=True')
+            parts.append('    auto_close=True')
         lines.append(",\n".join(parts) + ",\n)")
     (init_dir / "channels.py").write_text("\n\n".join(lines) + "\n" if lines else "")
 
@@ -174,11 +174,11 @@ def snapshot_image(repo, output_dir: Path, *, cogent_name: str | None = None) ->
     lines = []
     for c in cron_rules:
         parts = [f'add_cron({_repr_val(c.expression)}']
-        parts.append(f'    event_type={_repr_val(c.event_type)}')
+        parts.append(f'    channel_name={_repr_val(c.channel_name)}')
         if c.payload:
             parts.append(f'    payload={_repr_val(c.payload)}')
         if not c.enabled:
-            parts.append(f'    enabled=False')
+            parts.append('    enabled=False')
         lines.append(",\n".join(parts) + ",\n)")
     (init_dir / "cron.py").write_text("\n\n".join(lines) + "\n" if lines else "")
 

--- a/src/cogos/image/spec.py
+++ b/src/cogos/image/spec.py
@@ -49,9 +49,13 @@ def load_image(image_dir: Path) -> ImageSpec:
             "metadata": metadata or {},
         })
 
-    def add_cron(expression, *, event_type, payload=None, enabled=True):
+    def add_cron(expression, *, channel_name=None, event_type=None, payload=None, enabled=True):
+        target_channel = channel_name or event_type
+        if not target_channel:
+            raise TypeError("add_cron() requires channel_name")
         spec.cron_rules.append({
-            "expression": expression, "event_type": event_type,
+            "expression": expression,
+            "channel_name": target_channel,
             "payload": payload or {}, "enabled": enabled,
         })
 

--- a/src/cogos/io/discord/bridge.py
+++ b/src/cogos/io/discord/bridge.py
@@ -134,8 +134,9 @@ class DiscordBridge:
 
     def _get_repo(self):
         if self._repo is None:
-            from cogos.db.repository import Repository
-            self._repo = Repository.create()
+            from cogos.db.factory import create_repository
+
+            self._repo = create_repository()
         return self._repo
 
     def _get_bot_token(self) -> str:

--- a/src/cogos/runtime/dispatch.py
+++ b/src/cogos/runtime/dispatch.py
@@ -1,0 +1,47 @@
+"""Shared dispatch-envelope helpers for local and remote runtimes."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+
+def _load_message_payload(repo, message_id: str | None) -> dict[str, Any]:
+    if not message_id:
+        return {}
+
+    msg_uuid = UUID(message_id)
+
+    channel_messages = getattr(repo, "_channel_messages", None)
+    if isinstance(channel_messages, dict):
+        msg = channel_messages.get(msg_uuid)
+        if msg is not None:
+            return msg.payload or {}
+
+    try:
+        rows = repo.query(
+            "SELECT payload FROM cogos_channel_message WHERE id = :id",
+            {"id": msg_uuid},
+        )
+    except Exception:
+        return {}
+
+    if not rows:
+        return {}
+
+    json_field = getattr(repo, "_json_field", None)
+    if callable(json_field):
+        return json_field(rows[0], "payload", {})
+
+    payload = rows[0].get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def build_dispatch_event(repo, dispatch_result) -> dict[str, Any]:
+    """Build the executor event envelope used by both local and prod dispatch."""
+    return {
+        "process_id": dispatch_result.process_id,
+        "run_id": dispatch_result.run_id,
+        "message_id": dispatch_result.message_id,
+        "payload": _load_message_payload(repo, dispatch_result.message_id),
+    }

--- a/src/cogos/runtime/ingress.py
+++ b/src/cogos/runtime/ingress.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import UUID
 
 from cogos.db.models import ProcessStatus
+from cogos.runtime.dispatch import build_dispatch_event
 
 logger = logging.getLogger(__name__)
 
@@ -31,32 +32,7 @@ def dispatch_ready_processes(
             logger.warning("Dispatch failed for %s: %s", process_id, dispatch_result.error)
             continue
 
-        message_payload: dict[str, Any] = {}
-        if dispatch_result.message_id:
-            msg_id = UUID(dispatch_result.message_id)
-            # Try channel message lookup
-            for ch_msg in getattr(repo, '_channel_messages', {}).values():
-                if ch_msg.id == msg_id:
-                    message_payload = ch_msg.payload or {}
-                    break
-            else:
-                # RDS path: query by message ID
-                try:
-                    rows = repo.query(
-                        "SELECT payload FROM cogos_channel_message WHERE id = :id",
-                        {"id": msg_id},
-                    )
-                    if rows:
-                        message_payload = repo._json_field(rows[0], "payload", {})
-                except Exception:
-                    pass
-
-        payload = {
-            "process_id": dispatch_result.process_id,
-            "run_id": dispatch_result.run_id,
-            "message_id": dispatch_result.message_id,
-            "payload": message_payload,
-        }
+        payload = build_dispatch_event(repo, dispatch_result)
 
         try:
             response = lambda_client.invoke(

--- a/src/cogos/runtime/local.py
+++ b/src/cogos/runtime/local.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 import time
 from typing import Any, Callable
@@ -16,6 +17,8 @@ from cogos.db.models import (
     Run,
     RunStatus,
 )
+from cogos.runtime.dispatch import build_dispatch_event
+from cogos.runtime.schedule import apply_scheduled_messages
 
 logger = logging.getLogger(__name__)
 
@@ -83,22 +86,25 @@ def run_and_complete(
         )
 
         _emit_lifecycle(repo, process, {
-            "status": "success",
+            "type": "process:run:success",
             "run_id": str(run.id),
+            "process_id": str(process.id),
             "process_name": process.name,
             "duration_ms": duration_ms,
         })
 
-        # Transition process state
-        if process.mode.value == "daemon":
-            next_status = (
-                ProcessStatus.RUNNABLE
-                if repo.has_pending_deliveries(process.id)
-                else ProcessStatus.WAITING
-            )
-            repo.update_process_status(process.id, next_status)
-        else:
-            repo.update_process_status(process.id, ProcessStatus.COMPLETED)
+        # Transition process state — respect out-of-band status changes
+        current = repo.get_process(process.id)
+        if current and current.status not in (ProcessStatus.DISABLED, ProcessStatus.SUSPENDED):
+            if process.mode.value == "daemon":
+                next_status = (
+                    ProcessStatus.RUNNABLE
+                    if repo.has_pending_deliveries(process.id)
+                    else ProcessStatus.WAITING
+                )
+                repo.update_process_status(process.id, next_status)
+            else:
+                repo.update_process_status(process.id, ProcessStatus.COMPLETED)
 
     except Exception as e:
         duration_ms = int((time.time() - start) * 1000)
@@ -106,19 +112,26 @@ def run_and_complete(
         repo.complete_run(
             run.id,
             status=RunStatus.FAILED,
+            tokens_in=run.tokens_in,
+            tokens_out=run.tokens_out,
+            cost_usd=run.cost_usd,
             duration_ms=duration_ms,
             error=str(e)[:4000],
         )
 
         _emit_lifecycle(repo, process, {
-            "status": "failed",
+            "type": "process:run:failed",
             "run_id": str(run.id),
+            "process_id": str(process.id),
             "process_name": process.name,
             "error": str(e)[:1000],
         })
 
-        # Transition process state
-        if process.mode.value == "daemon":
+        # Retry logic — respect out-of-band status changes
+        current = repo.get_process(process.id)
+        if current and current.status in (ProcessStatus.DISABLED, ProcessStatus.SUSPENDED):
+            pass
+        elif process.mode.value == "daemon":
             next_status = (
                 ProcessStatus.RUNNABLE
                 if repo.has_pending_deliveries(process.id)
@@ -140,12 +153,15 @@ def run_local_tick(
     *,
     execute_fn: Callable | None = None,
     bedrock_client: Any | None = None,
+    now: datetime | None = None,
 ) -> int:
     """Run one tick of the local executor loop.
 
     Returns the number of processes executed.
     """
     scheduler = SchedulerCapability(repo, process_id=_SENTINEL_UUID)
+
+    apply_scheduled_messages(repo, now=now)
 
     # Backstop: ensure all channel messages have deliveries
     scheduler.match_messages()
@@ -165,18 +181,11 @@ def run_local_tick(
 
         process = repo.get_process(UUID(dispatch.process_id))
         run = repo.get_run(UUID(dispatch.run_id))
-
-        # Build payload from the channel message if available
-        message_payload: dict = {}
-        if dispatch.message_id:
-            msg_uuid = UUID(dispatch.message_id)
-            cm = repo._channel_messages.get(msg_uuid)
-            if cm is not None:
-                message_payload = cm.payload if cm.payload else {}
+        event_data = build_dispatch_event(repo, dispatch)
 
         run_and_complete(
             process,
-            message_payload,
+            event_data,
             run,
             config,
             repo,

--- a/src/cogos/runtime/schedule.py
+++ b/src/cogos/runtime/schedule.py
@@ -1,0 +1,120 @@
+"""Shared helpers for scheduled channel messages."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from cogos.db.models import Channel, ChannelMessage, ChannelType
+
+_FIELD_LIMITS = (
+    (0, 59),  # minute
+    (0, 23),  # hour
+    (1, 31),  # day of month
+    (1, 12),  # month
+    (0, 6),  # weekday; Sunday == 0
+)
+
+
+def _parse_int(value: str) -> int:
+    parsed = int(value)
+    return 0 if parsed == 7 else parsed
+
+
+def _field_matches(expr: str, value: int, lower: int, upper: int) -> bool:
+    for part in expr.split(","):
+        part = part.strip()
+        if not part:
+            continue
+
+        step = 1
+        base = part
+        if "/" in part:
+            base, step_raw = part.split("/", 1)
+            step = int(step_raw)
+            if step <= 0:
+                raise ValueError(f"invalid cron step {step_raw!r}")
+
+        if base == "*":
+            start = lower
+            end = upper
+        elif "-" in base:
+            start_raw, end_raw = base.split("-", 1)
+            start = _parse_int(start_raw)
+            end = _parse_int(end_raw)
+        else:
+            start = end = _parse_int(base)
+
+        if start < lower or end > upper or start > end:
+            raise ValueError(f"invalid cron range {part!r}")
+
+        if value < start or value > end:
+            continue
+
+        if (value - start) % step == 0:
+            return True
+
+    return False
+
+
+def cron_matches(expression: str, now: datetime) -> bool:
+    """Return True when a five-field cron expression matches *now*."""
+    fields = expression.split()
+    if len(fields) != 5:
+        raise ValueError(f"invalid cron expression {expression!r}")
+
+    values = (
+        now.minute,
+        now.hour,
+        now.day,
+        now.month,
+        (now.weekday() + 1) % 7,
+    )
+
+    return all(
+        _field_matches(field, value, lower, upper)
+        for field, value, (lower, upper) in zip(fields, values, _FIELD_LIMITS, strict=True)
+    )
+
+
+def _ensure_named_channel(repo, channel_name: str) -> Channel:
+    channel = repo.get_channel_by_name(channel_name)
+    if channel is not None:
+        return channel
+
+    repo.upsert_channel(Channel(name=channel_name, channel_type=ChannelType.NAMED))
+    channel = repo.get_channel_by_name(channel_name)
+    if channel is None:
+        raise RuntimeError(f"failed to create scheduled channel {channel_name}")
+    return channel
+
+
+def emit_channel_message(repo, channel_name: str, payload: dict | None = None) -> None:
+    """Append a message to a named channel, creating the channel if needed."""
+    channel = _ensure_named_channel(repo, channel_name)
+    repo.append_channel_message(
+        ChannelMessage(
+            channel=channel.id,
+            sender_process=None,
+            payload=payload or {},
+        )
+    )
+
+
+def apply_scheduled_messages(repo, *, now: datetime | None = None) -> int:
+    """Emit system tick and cron messages through the shared channel model."""
+    now = now or datetime.now(timezone.utc)
+
+    emitted = 0
+    emit_channel_message(repo, "system:tick:minute")
+    emitted += 1
+
+    if now.minute == 0:
+        emit_channel_message(repo, "system:tick:hour")
+        emitted += 1
+
+    for rule in repo.list_cron_rules(enabled_only=True):
+        if cron_matches(rule.expression, now):
+            emit_channel_message(repo, rule.channel_name, dict(rule.payload))
+            emitted += 1
+
+    return emitted

--- a/src/cogtainer/lambdas/dispatcher/handler.py
+++ b/src/cogtainer/lambdas/dispatcher/handler.py
@@ -5,12 +5,11 @@ EventBridge fires this every 60s. Each invocation:
 2. Matches channel messages to handlers
 3. Selects runnable processes and dispatches executors
 
-Virtual tick events match handlers directly and set processes to RUNNABLE.
+Virtual tick events are emitted as channel messages and wake handlers via deliveries.
 """
 
 from __future__ import annotations
 
-import logging
 import os
 from datetime import datetime, timezone
 from uuid import UUID
@@ -20,6 +19,7 @@ import boto3
 from cogtainer.lambdas.shared.config import get_config
 from cogtainer.lambdas.shared.logging import setup_logging
 from cogos.runtime.ingress import dispatch_ready_processes
+from cogos.runtime.schedule import apply_scheduled_messages
 
 logger = setup_logging()
 
@@ -91,23 +91,10 @@ def handler(event: dict, context) -> dict:
     return {"statusCode": 200, "dispatched": dispatched}
 
 
-def _apply_system_ticks(repo) -> None:
+def _apply_system_ticks(repo, *, now: datetime | None = None) -> None:
     """Generate virtual system:tick:minute (and :hour) events.
 
-    These match handlers and set processes to RUNNABLE but are never
-    written to the cogos_event table.
+    These now flow through the shared channel scheduler path so both
+    local and prod dispatch wake handlers the same way.
     """
-    from cogos.db.models import ProcessStatus
-
-    now = datetime.now(timezone.utc)
-    tick_types = ["system:tick:minute"]
-    if now.minute == 0:
-        tick_types.append("system:tick:hour")
-
-    for tick_type in tick_types:
-        handlers = repo.match_handlers(tick_type)
-        for h in handlers:
-            proc = repo.get_process(h.process)
-            if proc and proc.status == ProcessStatus.WAITING:
-                repo.update_process_status(h.process, ProcessStatus.RUNNABLE)
-                logger.info(f"System tick {tick_type} -> {proc.name} RUNNABLE")
+    apply_scheduled_messages(repo, now=now or datetime.now(timezone.utc))

--- a/tests/cogos/io/test_discord_bridge.py
+++ b/tests/cogos/io/test_discord_bridge.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 
+from cogos.db.local_repository import LocalRepository
 from cogos.db.models import Channel, ChannelType
+from cogos.io.discord import bridge as bridge_mod
 from cogos.io.discord.bridge import DiscordBridge, _reply_queue_latency_ms
 
 
@@ -84,3 +86,23 @@ async def test_relay_to_db_recreates_missing_system_channel():
     assert channel_message.payload["message_type"] == "discord:dm"
 
     bridge._start_typing.assert_called_once_with(msg.channel)
+
+
+def test_bridge_uses_local_repository_when_requested(monkeypatch, tmp_path):
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def event(self, fn):
+            return fn
+
+    monkeypatch.setenv("USE_LOCAL_DB", "1")
+    monkeypatch.setenv("COGENT_NAME", "local")
+    monkeypatch.setenv("COGENT_LOCAL_DATA", str(tmp_path))
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "dummy-token")
+    monkeypatch.setattr(bridge_mod.boto3, "client", lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr(bridge_mod.discord, "Client", _FakeClient)
+
+    bridge = DiscordBridge()
+
+    assert isinstance(bridge._get_repo(), LocalRepository)

--- a/tests/cogos/test_local_executor.py
+++ b/tests/cogos/test_local_executor.py
@@ -1,5 +1,7 @@
 """Tests for cogos.runtime.local – run_and_complete and run_local_tick."""
 
+from datetime import datetime, timezone
+
 from cogos.db.local_repository import LocalRepository
 from cogos.db.models import (
     Channel,
@@ -47,6 +49,10 @@ def _failing_execute(process, event_data, run, config, repo, **kwargs):
     raise RuntimeError("boom")
 
 
+def _process(name: str, *, mode=ProcessMode.ONE_SHOT, status=ProcessStatus.RUNNING) -> Process:
+    return Process(name=name, mode=mode, status=status, runner="local")
+
+
 # ---- Tests ----
 
 
@@ -85,7 +91,7 @@ def test_run_and_complete_failure_disables_one_shot(tmp_path):
     process = _make_process(repo, max_retries=0)
     run = _make_run(repo, process)
 
-    result = run_and_complete(
+    run_and_complete(
         process, {}, run, None, repo, execute_fn=_failing_execute,
     )
 
@@ -106,6 +112,39 @@ def test_run_and_complete_returns_run_on_failure(tmp_path):
     assert result.id == run.id
     assert repo.get_run(run.id).status == RunStatus.FAILED
     assert repo.get_process(process.id).status == ProcessStatus.RUNNABLE
+
+
+def test_local_repository_merges_stale_writers(tmp_path):
+    repo1 = _repo(tmp_path)
+    repo2 = _repo(tmp_path)
+
+    repo1.upsert_process(_process("p1", status=ProcessStatus.RUNNABLE))
+    repo2.upsert_process(_process("p2", status=ProcessStatus.RUNNABLE))
+
+    names = [process.name for process in _repo(tmp_path).list_processes()]
+    assert names == ["p1", "p2"]
+
+
+def test_run_and_complete_respects_out_of_band_disable(tmp_path):
+    repo = _repo(tmp_path)
+    process = _make_process(repo)
+    run = _make_run(repo, process)
+
+    def _disable_mid_run(process, event_data, run, config, repo, **kwargs):
+        repo.update_process_status(process.id, ProcessStatus.DISABLED)
+        return run
+
+    run_and_complete(
+        process,
+        {},
+        run,
+        None,
+        repo,
+        execute_fn=_disable_mid_run,
+    )
+
+    assert repo.get_run(run.id).status == RunStatus.COMPLETED
+    assert repo.get_process(process.id).status == ProcessStatus.DISABLED
 
 
 # ---- run_local_tick tests ----
@@ -173,3 +212,66 @@ def test_run_local_tick_matches_channel_messages(tmp_path):
 
     assert executed == 1
     assert repo.get_process(p.id).status == ProcessStatus.WAITING
+
+
+def test_run_local_tick_uses_prod_dispatch_envelope(tmp_path):
+    repo = _repo(tmp_path)
+    process = Process(
+        name="daemon-proc",
+        mode=ProcessMode.DAEMON,
+        status=ProcessStatus.WAITING,
+        runner="local",
+    )
+    repo.upsert_process(process)
+
+    channel = Channel(name="test-channel", channel_type=ChannelType.NAMED)
+    repo.upsert_channel(channel)
+    channel = repo.get_channel_by_name("test-channel")
+
+    repo.create_handler(Handler(process=process.id, channel=channel.id, enabled=True))
+    message = ChannelMessage(
+        channel=channel.id,
+        sender_process=process.id,
+        payload={"hello": "world"},
+    )
+    repo.append_channel_message(message)
+
+    captured = {}
+
+    def _capture_execute(process, event_data, run, config, repo, **kwargs):
+        captured.update(event_data)
+        return run
+
+    executed = run_local_tick(repo, None, execute_fn=_capture_execute)
+
+    assert executed == 1
+    assert captured["process_id"] == str(process.id)
+    assert captured["run_id"]
+    assert captured["message_id"] == str(message.id)
+    assert captured["payload"] == {"hello": "world"}
+
+
+def test_run_local_tick_applies_system_ticks(tmp_path):
+    repo = _repo(tmp_path)
+    process = Process(
+        name="hourly-daemon",
+        mode=ProcessMode.DAEMON,
+        status=ProcessStatus.WAITING,
+        runner="local",
+    )
+    repo.upsert_process(process)
+
+    channel = Channel(name="system:tick:hour", channel_type=ChannelType.NAMED)
+    repo.upsert_channel(channel)
+    channel = repo.get_channel_by_name("system:tick:hour")
+    repo.create_handler(Handler(process=process.id, channel=channel.id, enabled=True))
+
+    executed = run_local_tick(
+        repo,
+        None,
+        execute_fn=_noop_execute,
+        now=datetime(2026, 3, 13, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert executed == 1
+    assert repo.get_process(process.id).status == ProcessStatus.WAITING

--- a/tests/cogos/test_scheduler_ingress.py
+++ b/tests/cogos/test_scheduler_ingress.py
@@ -1,8 +1,11 @@
+from datetime import datetime, timezone
 from uuid import UUID
 
 from cogos.capabilities.scheduler import SchedulerCapability
 from cogos.db.local_repository import LocalRepository
-from cogos.db.models import Channel, ChannelMessage, ChannelType, DeliveryStatus, Handler, Process, ProcessMode, ProcessStatus, RunStatus
+from cogos.db.models import Channel, ChannelMessage, ChannelType, Cron, DeliveryStatus, Handler, Process, ProcessMode, ProcessStatus, RunStatus
+from cogos.runtime.schedule import apply_scheduled_messages
+from cogtainer.lambdas.dispatcher.handler import _apply_system_ticks
 from cogos.runtime.ingress import dispatch_ready_processes
 
 
@@ -128,3 +131,47 @@ def test_dispatch_rolls_back_failed_invoke(tmp_path):
     delivery = next(iter(repo._deliveries.values()))
     assert delivery.status == DeliveryStatus.PENDING
     assert delivery.run is None
+
+
+def test_apply_system_ticks_wakes_channel_subscribers(tmp_path):
+    repo = _repo(tmp_path)
+    proc = _daemon("hourly")
+    repo.upsert_process(proc)
+
+    channel = Channel(name="system:tick:hour", channel_type=ChannelType.NAMED)
+    repo.upsert_channel(channel)
+    channel = repo.get_channel_by_name("system:tick:hour")
+    repo.create_handler(Handler(process=proc.id, channel=channel.id))
+
+    _apply_system_ticks(repo, now=datetime(2026, 3, 13, 12, 0, tzinfo=timezone.utc))
+
+    assert repo.get_process(proc.id).status == ProcessStatus.RUNNABLE
+    assert len(repo.get_pending_deliveries(proc.id)) == 1
+
+
+def test_apply_scheduled_messages_emits_matching_cron_channels(tmp_path):
+    repo = _repo(tmp_path)
+    proc = _daemon("cron-worker")
+    repo.upsert_process(proc)
+
+    channel = Channel(name="check:health", channel_type=ChannelType.NAMED)
+    repo.upsert_channel(channel)
+    channel = repo.get_channel_by_name("check:health")
+    repo.create_handler(Handler(process=proc.id, channel=channel.id))
+    repo.upsert_cron(
+        Cron(
+            expression="15 8 * * *",
+            channel_name="check:health",
+            payload={"kind": "cron"},
+        )
+    )
+
+    emitted = apply_scheduled_messages(
+        repo,
+        now=datetime(2026, 3, 13, 8, 15, tzinfo=timezone.utc),
+    )
+
+    assert emitted >= 2
+    assert repo.get_process(proc.id).status == ProcessStatus.RUNNABLE
+    messages = repo.list_channel_messages(channel.id)
+    assert messages[-1].payload == {"kind": "cron"}


### PR DESCRIPTION
## Problem

Local execution had become usable, but it still diverged from production in a few important ways.

`run-local`, the local Discord bridge, and the dashboard can all point at the same local state store, but `LocalRepository` was still a whole-file JSON writer with no locking or merge semantics. That made the documented multi-process local workflow vulnerable to stale writers dropping each other's state.

The local execution path also still behaved differently from the Lambda path: daemon-triggered local runs passed a bare channel payload instead of the executor-style envelope, local completion could overwrite out-of-band `DISABLED` / `SUSPENDED` operator actions, and system ticks / cron were still split between the old event-type matcher and the newer channel model. On top of that, `cogent local cogos io discord run-local` still ignored `USE_LOCAL_DB=1` and tried to build an RDS Data API repository.

Closes #33.

## Summary

- Add a shared repository factory so the CLI, executor, and Discord bridge all honor `USE_LOCAL_DB=1`.
- Harden `LocalRepository` persistence with reload-before-write, lock-and-merge semantics, and atomic file replacement so concurrent local processes preserve each other's updates.
- Share dispatch envelope construction between local and prod so local runs receive the same `{process_id, run_id, message_id, payload}` event shape that the executor Lambda receives.
- Route system ticks and cron through named channels and channel messages in both local and prod, including `cogent local cogos run-local`.
- Preserve out-of-band `DISABLED` / `SUSPENDED` transitions when local runs complete, matching the executor Lambda behavior.
- Update cron image load/snapshot paths to use `channel_name` consistently while keeping compatibility with existing `event_type` image definitions.
- Add regressions for stale local writers, local envelope shape, local Discord repo selection, out-of-band disable preservation, and tick / cron wakeups.

## Testing

- `uv sync --all-extras`
- `uv run python -m compileall src/cogos src/cogtainer/lambdas/dispatcher tests/cogos`
- `uv run pytest tests/cogos/test_local_executor.py tests/cogos/test_scheduler_ingress.py tests/cogos/test_executor_handler.py tests/cogos/io/test_discord_bridge.py tests/cogos/test_image_apply.py tests/cogos/test_image_snapshot.py -q`
- `uv run pytest tests/cogos/db/test_local_repo_channels.py tests/cogos/test_scheduler_channels.py tests/cogos/test_image_e2e.py -q`
- `uv run polis status`
