### PR TITLE
feat(cogos): resolve prompt includes and validate filesystem-lab locally

### DIFF
--- a/dashboard/frontend/src/components/files/FilesPanel.tsx
+++ b/dashboard/frontend/src/components/files/FilesPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import type { CogosFile, CogosFileVersion } from "@/lib/types";
 import { Badge } from "@/components/shared/Badge";
 import { HierarchyPanel, findNode, getAllItems, buildTree } from "@/components/shared/HierarchyPanel";
+import { PromptTextarea } from "@/components/shared/PromptTextarea";
 import { fmtTimestamp } from "@/lib/format";
 import {
   getFileDetail,
@@ -34,9 +35,10 @@ interface VersionPanelProps {
   canMutate: boolean;
   onRefresh?: () => void;
   onClose: () => void;
+  promptSuggestions: string[];
 }
 
-function VersionPanel({ file, cogentName, canMutate, onRefresh, onClose }: VersionPanelProps) {
+function VersionPanel({ file, cogentName, canMutate, onRefresh, onClose, promptSuggestions }: VersionPanelProps) {
   const [versions, setVersions] = useState<CogosFileVersion[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
@@ -308,13 +310,15 @@ function VersionPanel({ file, cogentName, canMutate, onRefresh, onClose }: Versi
             {currentVersion && (
               editing ? (
                 <div className="space-y-2">
-                  <textarea
+                  <PromptTextarea
                     value={editContent}
-                    onChange={(e) => { setEditContent(e.target.value); setSaveConfirm(null); }}
+                    onChange={(nextValue) => { setEditContent(nextValue); setSaveConfirm(null); }}
+                    suggestions={promptSuggestions}
                     rows={12}
                     className="w-full px-2 py-1.5 text-[12px] rounded border font-mono resize-y"
                     style={inputStyle}
                   />
+                  <div className="text-[10px] text-[var(--text-muted)]">{"Type '@{' to insert a file reference."}</div>
                   <div className="flex gap-1.5 items-center flex-wrap">
                     {saveConfirm === "update" ? (
                       <span className="flex items-center gap-1 text-[11px]">
@@ -375,6 +379,7 @@ export function FilesPanel({ files, cogentName, onRefresh }: FilesPanelProps) {
   const [creating, setCreating] = useState(false);
   const [newKey, setNewKey] = useState("");
   const [newContent, setNewContent] = useState("");
+  const fileSuggestions = useMemo(() => files.map((file) => file.key), [files]);
 
   const displayItems = useMemo(() => {
     if (!selectedPath) return files;
@@ -458,14 +463,18 @@ export function FilesPanel({ files, cogentName, onRefresh }: FilesPanelProps) {
             <label className="block text-[10px] text-[var(--text-muted)] uppercase tracking-wide mb-1">
               Content
             </label>
-            <textarea
+            <PromptTextarea
               value={newContent}
-              onChange={(e) => setNewContent(e.target.value)}
+              onChange={setNewContent}
+              suggestions={fileSuggestions}
               placeholder="File content..."
               rows={5}
               className="w-full px-2 py-1.5 text-[12px] rounded border font-mono resize-y"
               style={inputStyle}
             />
+            <div className="text-[9px] text-[var(--text-muted)] mt-1">
+              {"Type '@{' to insert another file key."}
+            </div>
           </div>
           <div className="flex gap-2">
             <button
@@ -582,13 +591,14 @@ export function FilesPanel({ files, cogentName, onRefresh }: FilesPanelProps) {
             zIndex: 20,
           }}
         >
-          <VersionPanel
-            file={activeSelectedFile}
-            cogentName={cogentName}
-            canMutate={canMutate}
-            onRefresh={onRefresh}
-            onClose={() => setSelectedFile(null)}
-          />
+            <VersionPanel
+              file={activeSelectedFile}
+              cogentName={cogentName}
+              canMutate={canMutate}
+              onRefresh={onRefresh}
+              onClose={() => setSelectedFile(null)}
+              promptSuggestions={fileSuggestions}
+            />
         </div>
       )}
     </div>

--- a/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
+++ b/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import type { CogosProcess, CogosProcessRun, Resource, CogosRun, CogosFile, CogosCapability, EventType } from "@/lib/types";
 import { Badge } from "@/components/shared/Badge";
 import { JsonViewer } from "@/components/shared/JsonViewer";
+import { PromptTextarea } from "@/components/shared/PromptTextarea";
 import type { CogosFileVersion } from "@/lib/types";
 import * as api from "@/lib/api";
 import { fmtTimestamp } from "@/lib/format";
@@ -144,6 +145,26 @@ function fmtTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+function grantAllowsPromptRead(grant: CapGrant, key: string): boolean {
+  if (!["file", "dir", "files"].includes(grant.capability_name)) return false;
+
+  const config = (grant.config || {}) as Record<string, unknown>;
+  const ops = config.ops;
+  if (Array.isArray(ops) && !ops.includes("read")) return false;
+
+  const scopedKey = typeof config.key === "string" ? config.key : "";
+  const prefix = typeof config.prefix === "string" ? config.prefix : "";
+  if (scopedKey) return key === scopedKey;
+  if (prefix) return key.startsWith(prefix);
+  return true;
+}
+
+function filterPromptSuggestions(allKeys: string[], grants: CapGrant[]): string[] {
+  const fileGrants = grants.filter((grant) => ["file", "dir", "files"].includes(grant.capability_name));
+  if (fileGrants.length === 0) return [];
+  return allKeys.filter((key) => fileGrants.some((grant) => grantAllowsPromptRead(grant, key)));
 }
 
 /* ── TagListEditor: editable list with typeahead ── */
@@ -1298,11 +1319,13 @@ function InlineFileEditor({
   cogentName,
   onRefresh,
   onClose,
+  promptSuggestions = [],
 }: {
   fileKey: string;
   cogentName: string;
   onRefresh?: () => void;
   onClose: () => void;
+  promptSuggestions?: string[];
 }) {
   const [versions, setVersions] = useState<CogosFileVersion[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1450,13 +1473,15 @@ function InlineFileEditor({
       {currentVersion && (
         editing ? (
           <div className="px-2 py-1.5 space-y-1.5">
-            <textarea
+            <PromptTextarea
               value={editContent}
-              onChange={(e) => { setEditContent(e.target.value); setSaveConfirm(null); }}
+              onChange={(nextValue) => { setEditContent(nextValue); setSaveConfirm(null); }}
+              suggestions={promptSuggestions}
               rows={8}
               className="w-full px-2 py-1 text-[11px] rounded border font-mono resize-y"
               style={{ background: "var(--bg-base)", borderColor: "var(--border)", color: "var(--text-primary)" }}
             />
+            <div className="text-[9px] text-[var(--text-muted)]">{"Type '@{' to insert a file reference."}</div>
             <div className="flex gap-1.5 items-center flex-wrap">
               {saveConfirm === "update" ? (
                 <span className="flex items-center gap-1 text-[10px]">
@@ -1514,6 +1539,7 @@ function ProcessFormEditor({
   isNew,
   resourceSuggestions,
   fileSuggestions,
+  promptSuggestions,
   capabilitySuggestions,
   eventTypeSuggestions,
   cogentName,
@@ -1529,6 +1555,7 @@ function ProcessFormEditor({
   isNew: boolean;
   resourceSuggestions: string[];
   fileSuggestions: string[];
+  promptSuggestions: string[];
   capabilitySuggestions: string[];
   eventTypeSuggestions: string[];
   cogentName: string;
@@ -1642,10 +1669,10 @@ function ProcessFormEditor({
         </div>
       </div>
 
-      {/* Context (files) — collapsible rows with inline editing */}
+      {/* Prompt files — collapsible rows with inline editing */}
       <div>
         <div className="flex items-center gap-2 mb-1">
-          <label className="text-[10px] text-[var(--text-muted)] uppercase">Context</label>
+          <label className="text-[10px] text-[var(--text-muted)] uppercase">Prompt Files</label>
         </div>
         {((includes && includes.length > 0) || form.files.length > 0) && (
           <div className="rounded overflow-hidden mb-1" style={{ border: "1px solid var(--border)" }}>
@@ -1675,6 +1702,7 @@ function ProcessFormEditor({
                       cogentName={cogentName}
                       onRefresh={onRefresh}
                       onClose={() => setExpandedEditFiles((prev) => { const next = new Set(prev); next.delete(inc.key); return next; })}
+                      promptSuggestions={promptSuggestions}
                     />
                   )}
                 </div>
@@ -1764,6 +1792,7 @@ function ProcessFormEditor({
                       cogentName={cogentName}
                       onRefresh={onRefresh}
                       onClose={() => setExpandedEditFiles((prev) => { const next = new Set(prev); next.delete(fileKey); return next; })}
+                      promptSuggestions={promptSuggestions}
                     />
                   )}
                 </div>
@@ -1786,16 +1815,18 @@ function ProcessFormEditor({
         />
       </div>
 
-      {/* Content */}
+      {/* Prompt source */}
       <div>
-        <label className="text-[10px] text-[var(--text-muted)] uppercase block mb-1">Content (prompt)</label>
-        <textarea
+        <label className="text-[10px] text-[var(--text-muted)] uppercase block mb-1">Prompt Source</label>
+        <PromptTextarea
           className={INPUT_CLS}
           rows={4}
           value={form.content}
-          onChange={(e) => onChange({ ...form, content: e.target.value })}
+          onChange={(content) => onChange({ ...form, content })}
+          suggestions={promptSuggestions}
           style={{ resize: "vertical" }}
         />
+        <div className="text-[9px] text-[var(--text-muted)] mt-1">{"Type '@{' to insert a readable file reference."}</div>
       </div>
 
       {/* Files & Directories — quick-add for file/dir capabilities */}
@@ -1900,6 +1931,18 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
   const fileSuggestions = useMemo(() => files.map((f) => f.key), [files]);
   const capabilitySuggestions = useMemo(() => capabilities.map((c) => c.name), [capabilities]);
   const eventTypeSuggestions = useMemo(() => eventTypes.map((et) => et.name), [eventTypes]);
+  const formPromptSuggestions = useMemo(() => filterPromptSuggestions(fileSuggestions, form.grants), [fileSuggestions, form.grants]);
+  const detailPromptSuggestions = useMemo(
+    () => filterPromptSuggestions(
+      fileSuggestions,
+      detailCapGrants.map((grant) => ({
+        grant_name: grant.grant_name,
+        capability_name: grant.capability_name,
+        config: grant.config,
+      })),
+    ),
+    [fileSuggestions, detailCapGrants],
+  );
 
   // Build map of process_id -> latest run from the runs list
   const lastRunByProcess = useMemo(() => {
@@ -2092,6 +2135,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
             isNew
             resourceSuggestions={resourceSuggestions}
             fileSuggestions={fileSuggestions}
+            promptSuggestions={formPromptSuggestions}
             capabilitySuggestions={capabilitySuggestions}
             eventTypeSuggestions={eventTypeSuggestions}
             cogentName={cogentName}
@@ -2290,6 +2334,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                                     cogentName={cogentName}
                                     onRefresh={async () => { onRefresh(); await fetchDetail(proc.id, { preserveExpanded: true }); }}
                                     onClose={() => setEditingFileKey(null)}
+                                    promptSuggestions={detailPromptSuggestions}
                                   />
                                 ) : (
                                   <div
@@ -2307,6 +2352,26 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                     </div>
                     );
                   })()}
+
+                  {resolvedPrompt && (
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => setShowResolved((current) => !current)}
+                        className="text-[10px] text-[var(--text-muted)] uppercase bg-transparent border-0 cursor-pointer p-0 mb-1 hover:text-[var(--accent)]"
+                      >
+                        {showResolved ? "Hide" : "Show"} Resolved Prompt
+                      </button>
+                      {showResolved && (
+                        <pre
+                          className="m-0 rounded px-3 py-2 text-[11px] font-mono whitespace-pre-wrap break-words"
+                          style={{ background: "var(--bg-surface)", border: "1px solid var(--border)", color: "var(--text-secondary)" }}
+                        >
+                          {resolvedPrompt}
+                        </pre>
+                      )}
+                    </div>
+                  )}
 
                   {/* Files & Directories */}
                   {(() => {
@@ -2523,6 +2588,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                     isNew={false}
                     resourceSuggestions={resourceSuggestions}
                     fileSuggestions={fileSuggestions}
+                    promptSuggestions={formPromptSuggestions}
                     capabilitySuggestions={capabilitySuggestions}
                     eventTypeSuggestions={eventTypeSuggestions}
                     cogentName={cogentName}

--- a/dashboard/frontend/src/components/shared/PromptTextarea.tsx
+++ b/dashboard/frontend/src/components/shared/PromptTextarea.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import type { CSSProperties, KeyboardEvent } from "react";
+
+interface ActiveInclude {
+  start: number;
+  end: number;
+  query: string;
+}
+
+interface PromptTextareaProps {
+  value: string;
+  onChange: (value: string) => void;
+  suggestions: string[];
+  rows?: number;
+  placeholder?: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+function getActiveInclude(value: string, caret: number): ActiveInclude | null {
+  const beforeCaret = value.slice(0, caret);
+  const start = beforeCaret.lastIndexOf("@{");
+  if (start === -1) return null;
+
+  const query = beforeCaret.slice(start + 2);
+  if (query.includes("}") || query.includes("\n")) return null;
+  return { start, end: caret, query };
+}
+
+export function PromptTextarea({
+  value,
+  onChange,
+  suggestions,
+  rows = 5,
+  placeholder,
+  className,
+  style,
+}: PromptTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [activeInclude, setActiveInclude] = useState<ActiveInclude | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const filteredSuggestions = useMemo(() => {
+    if (!activeInclude) return [];
+    const query = activeInclude.query.trim().toLowerCase();
+    const items = suggestions.filter((suggestion) => {
+      if (!query) return true;
+      return suggestion.toLowerCase().includes(query);
+    });
+    items.sort((a, b) => {
+      const aStarts = query ? a.toLowerCase().startsWith(query) : false;
+      const bStarts = query ? b.toLowerCase().startsWith(query) : false;
+      if (aStarts !== bStarts) return aStarts ? -1 : 1;
+      return a.localeCompare(b);
+    });
+    return items.slice(0, 8);
+  }, [activeInclude, suggestions]);
+
+  const updateIncludeState = (nextValue: string, caret: number | null) => {
+    const nextInclude = caret == null ? null : getActiveInclude(nextValue, caret);
+    setActiveInclude(nextInclude);
+    setSelectedIndex(0);
+  };
+
+  const insertSuggestion = (suggestion: string) => {
+    if (!activeInclude) return;
+    const nextValue =
+      `${value.slice(0, activeInclude.start)}@{${suggestion}}${value.slice(activeInclude.end)}`;
+    const nextCaret = activeInclude.start + suggestion.length + 3;
+    onChange(nextValue);
+    setActiveInclude(null);
+    setSelectedIndex(0);
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      textareaRef.current?.setSelectionRange(nextCaret, nextCaret);
+    });
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!activeInclude || filteredSuggestions.length === 0) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex((current) => (current + 1) % filteredSuggestions.length);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex((current) => (current - 1 + filteredSuggestions.length) % filteredSuggestions.length);
+      return;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      insertSuggestion(filteredSuggestions[selectedIndex] ?? filteredSuggestions[0]);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setActiveInclude(null);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        rows={rows}
+        placeholder={placeholder}
+        className={className}
+        style={style}
+        onChange={(event) => {
+          const nextValue = event.target.value;
+          onChange(nextValue);
+          updateIncludeState(nextValue, event.target.selectionStart);
+        }}
+        onKeyDown={onKeyDown}
+        onSelect={(event) => updateIncludeState(value, event.currentTarget.selectionStart)}
+        onClick={(event) => updateIncludeState(value, event.currentTarget.selectionStart)}
+        onBlur={() => setActiveInclude(null)}
+      />
+      {activeInclude && filteredSuggestions.length > 0 && (
+        <div
+          className="absolute left-0 right-0 mt-1 z-50 rounded overflow-hidden shadow-lg"
+          style={{ background: "var(--bg-elevated)", border: "1px solid var(--border)" }}
+        >
+          {filteredSuggestions.map((suggestion, index) => {
+            const isSelected = index === selectedIndex;
+            return (
+              <button
+                key={suggestion}
+                type="button"
+                className="w-full text-left px-2 py-1 text-[11px] font-mono border-0 cursor-pointer"
+                style={{
+                  background: isSelected ? "var(--bg-hover)" : "transparent",
+                  color: isSelected ? "var(--accent)" : "var(--text-secondary)",
+                }}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  insertSuggestion(suggestion);
+                }}
+              >
+                {`@{${suggestion}}`}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/images/cogent-v1/apps/filesystem-lab/design.md
+++ b/images/cogent-v1/apps/filesystem-lab/design.md
@@ -1,0 +1,39 @@
+# Filesystem Lab
+
+Reusable prompt assets for testing the local CogOS file store, authored `@{file-key}`
+resolution, and the dashboard prompt preview flow.
+
+## What It Covers
+
+- Prompt files that use inline `@{...}` references
+- Nested prompt references with deduped shared dependencies
+- Legacy `File.includes` wiring via `add_file(...)`
+- A sample one-shot process and a sample daemon process you can load locally
+
+## Suggested Local Workflow
+
+1. Boot the image locally.
+2. Load `processes.json` to create the test processes.
+3. Inspect the prompt preview for `filesystem-lab/respond` in the dashboard.
+4. Trigger the daemon through `filesystem-lab:requests`, or run the smoke process directly.
+5. Inspect the report file written under `apps/filesystem-lab/output/`.
+
+## Sample Commands
+
+```bash
+cogent local cogos image boot cogent-v1 --clean
+cogent local cogos process load images/cogent-v1/apps/filesystem-lab/respond.json
+
+cogent local cogos process get filesystem-lab/respond
+cogent local cogos file get apps/filesystem-lab/prompts/respond.md
+
+cogent local cogos channel send filesystem-lab:requests \
+  --payload '{"task_key": "apps/filesystem-lab/fixtures/sample-task.md", "goal": "verify prompt resolution and file writes"}'
+
+cogent local cogos run-local --once
+cogent local cogos file get apps/filesystem-lab/output/latest-report.md
+
+# Optional one-shot smoke test
+cogent local cogos process load images/cogent-v1/apps/filesystem-lab/smoke.json
+cogent local cogos process run filesystem-lab/smoke --local
+```

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/fixtures/sample-task.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/fixtures/sample-task.md
@@ -1,0 +1,7 @@
+Task: verify that the local CogOS file store and authored prompt resolver are working.
+
+Inspect the filesystem-lab app files, then write a markdown report to
+`apps/filesystem-lab/output/smoke-report.md`.
+
+In the report, state whether the resolved prompt included nested `@{...}` references
+and list the exact file keys you inspected.

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/playbooks/operating-rules.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/playbooks/operating-rules.md
@@ -1,0 +1,12 @@
+Before writing output, inspect the app directory with `dir.list(prefix="apps/filesystem-lab/")`.
+
+Then read the task file you plan to use and keep the final output auditable.
+
+Every report must include:
+
+- trigger summary
+- files inspected
+- files written
+- one next suggested experiment
+
+Formatting rules are in @{apps/filesystem-lab/playbooks/shared-style.md}

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/playbooks/report-format.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/playbooks/report-format.md
@@ -1,0 +1,9 @@
+Use this report shape:
+
+# Filesystem Lab Report
+## Trigger
+## Files Inspected
+## Files Written
+## Notes
+
+Apply the tone guide in @{apps/filesystem-lab/playbooks/shared-style.md}

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/playbooks/shared-style.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/playbooks/shared-style.md
@@ -1,0 +1,5 @@
+Write concise markdown.
+
+Always mention exact file keys that you read or wrote.
+If an expected file is missing, say exactly which key was missing.
+Do not invent file contents.

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/prompts/respond.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/prompts/respond.md
@@ -1,0 +1,15 @@
+Handle the incoming filesystem lab request.
+
+Use @{apps/filesystem-lab/playbooks/operating-rules.md}
+Use @{apps/filesystem-lab/playbooks/report-format.md}
+
+If the payload contains a `task_key`, read that file first.
+Otherwise, use @{apps/filesystem-lab/fixtures/sample-task.md}
+
+Then:
+
+1. Inspect the app files with `dir.list(prefix="apps/filesystem-lab/")`.
+2. Read the task file you selected.
+3. Write a markdown report to `apps/filesystem-lab/output/latest-report.md`.
+4. Write a short scratch note through `me.process().scratch().write(...)` recording the report key.
+5. Reply with the exact output keys you wrote.

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/prompts/smoke.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/prompts/smoke.md
@@ -1,0 +1,15 @@
+Run a deterministic local filesystem smoke test.
+
+Use @{apps/filesystem-lab/playbooks/operating-rules.md}
+Use @{apps/filesystem-lab/playbooks/report-format.md}
+Use @{apps/filesystem-lab/fixtures/sample-task.md}
+
+Do not ask follow-up questions.
+
+Inspect the app directory and write a markdown report to
+`apps/filesystem-lab/output/smoke-report.md`.
+
+Also write a short scratch note through `me.process().scratch().write(...)` that records
+the report key.
+
+In your final answer, only list the files you wrote.

--- a/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/whoami.md
+++ b/images/cogent-v1/apps/filesystem-lab/files/apps/filesystem-lab/whoami.md
@@ -1,0 +1,6 @@
+You are the Filesystem Lab worker.
+
+Your job is to validate that local prompt resolution and file operations behave the
+same way in the dashboard preview and in executor runs.
+
+Prefer deterministic behavior, short reports, and explicit file keys.

--- a/images/cogent-v1/apps/filesystem-lab/init/prompts.py
+++ b/images/cogent-v1/apps/filesystem-lab/init/prompts.py
@@ -1,0 +1,9 @@
+# Filesystem lab prompt bundles.
+
+add_file("apps/filesystem-lab/prompts/respond.md", content="", includes=[
+    "apps/filesystem-lab/whoami.md",
+])
+
+add_file("apps/filesystem-lab/prompts/smoke.md", content="", includes=[
+    "apps/filesystem-lab/whoami.md",
+])

--- a/images/cogent-v1/apps/filesystem-lab/processes.json
+++ b/images/cogent-v1/apps/filesystem-lab/processes.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "filesystem-lab/respond",
+    "mode": "daemon",
+    "content": "",
+    "code_key": "apps/filesystem-lab/prompts/respond.md",
+    "runner": "lambda",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "priority": 4.0,
+    "capabilities": ["dir", "me"],
+    "handlers": ["filesystem-lab:requests"]
+  },
+  {
+    "name": "filesystem-lab/smoke",
+    "mode": "one_shot",
+    "content": "",
+    "code_key": "apps/filesystem-lab/prompts/smoke.md",
+    "runner": "lambda",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "priority": 2.0,
+    "capabilities": ["dir", "me"],
+    "handlers": []
+  }
+]

--- a/images/cogent-v1/apps/filesystem-lab/respond.json
+++ b/images/cogent-v1/apps/filesystem-lab/respond.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "filesystem-lab/respond",
+    "mode": "daemon",
+    "content": "",
+    "code_key": "apps/filesystem-lab/prompts/respond.md",
+    "runner": "lambda",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "priority": 4.0,
+    "capabilities": ["dir", "me"],
+    "handlers": ["filesystem-lab:requests"]
+  }
+]

--- a/images/cogent-v1/apps/filesystem-lab/smoke.json
+++ b/images/cogent-v1/apps/filesystem-lab/smoke.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "filesystem-lab/smoke",
+    "mode": "one_shot",
+    "content": "",
+    "code_key": "apps/filesystem-lab/prompts/smoke.md",
+    "runner": "lambda",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "priority": 2.0,
+    "capabilities": ["dir", "me"],
+    "handlers": []
+  }
+]

--- a/src/cogos/cli/__main__.py
+++ b/src/cogos/cli/__main__.py
@@ -454,7 +454,7 @@ def process_load(file_path: str):
             if not cap:
                 click.echo(f"    Warning: capability '{cap_name}' not found")
                 continue
-            pc = ProcessCapability(process=pid, capability=cap.id)
+            pc = ProcessCapability(process=pid, capability=cap.id, name=cap_name)
             repo.create_process_capability(pc)
             click.echo(f"    Bound capability: {cap_name}")
 

--- a/src/cogos/executor/handler.py
+++ b/src/cogos/executor/handler.py
@@ -260,29 +260,27 @@ def execute_process(
     """Execute process via Bedrock converse API with search + run_code tool loop."""
     bedrock = bedrock_client or boto3.client("bedrock-runtime", region_name=config.region)
 
-    # Build system prompt using the shared ContextEngine
+    # Build system prompt using the shared authored-prompt resolver.
     from cogos.files.context_engine import ContextEngine
-    from cogos.files.store import FileStore
-    file_store = FileStore(repo)
-    ctx = ContextEngine(file_store)
+    ctx = ContextEngine(repo)
     system_prompt = ctx.generate_full_prompt(process)
 
     if not system_prompt:
         system_prompt = "You are a CogOS process. Follow your instructions and use capabilities to accomplish your task."
 
-    # Prepend includes — all files under "cogos/includes/" are auto-injected
-    includes_content = _load_includes(repo)
-    if includes_content:
-        system_prompt = includes_content + "\n\n" + system_prompt
-
     system = [{"text": system_prompt}]
 
-    # Build user message from process content + event
+    # Build user message from runtime event data only. Authored prompt sources
+    # are already resolved into the system prompt before inference.
     user_text = ""
-    if process.content:
-        user_text += process.content + "\n\n"
-    if event_data.get("payload"):
-        user_text += f"Message payload: {json.dumps(event_data['payload'], indent=2)}\n"
+    if event_data.get("event_type"):
+        user_text += f"Event: {event_data.get('event_type', 'unknown')}\n"
+
+    payload = event_data.get("payload")
+    if payload is None and event_data and not any(key in event_data for key in ("process_id", "message_id", "run_id")):
+        payload = event_data
+    if payload is not None:
+        user_text += f"Payload: {json.dumps(payload, indent=2)}\n"
     if not user_text.strip():
         user_text = "Execute your task."
 

--- a/src/cogos/files/context_engine.py
+++ b/src/cogos/files/context_engine.py
@@ -1,199 +1,293 @@
-"""Context engine -- resolves file includes to build full prompt context.
-
-Files in CogOS can declare an ``includes`` list of other file keys. The
-context engine recursively resolves those includes, concatenates their
-content with section headers, and returns a single string suitable for
-injection into an LLM prompt.
-
-Circular includes are detected and reported as errors in the output.
-"""
+"""Capability-scoped prompt resolver for CogOS authored prompt sources."""
 
 from __future__ import annotations
 
-import logging
+import re
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from cogos.files.store import FileStore
 
 if TYPE_CHECKING:
-    from cogos.db.models import Process
+    from cogos.db.models import File, Process
+    from cogos.db.repository import Repository
 
-logger = logging.getLogger(__name__)
+
+INLINE_INCLUDE_RE = re.compile(r"@\{([^{}\n]+)\}")
+GLOBAL_INCLUDE_PREFIX = "cogos/includes/"
+CONTENT_KEY = "<content>"
+
+
+@dataclass
+class PromptResolution:
+    text: str
+    prompt_tree: list[dict]
+
+
+@dataclass
+class _PromptEntry:
+    key: str
+    content: str
+    is_direct: bool
+
+
+@dataclass
+class _ResolutionState:
+    root_keys: set[str]
+    bundle_entries: list[_PromptEntry] = field(default_factory=list)
+    emitted_bundle_keys: set[str] = field(default_factory=set)
+
+
+class _FileAccessView:
+    """Capability-scoped read view used during prompt assembly."""
+
+    def __init__(self, repo: Repository, process: Process | None) -> None:
+        self._repo = repo
+        self._allow_all = process is None
+        self._exact_keys: set[str] = set()
+        self._prefixes: list[str] = []
+        if process is not None:
+            self._load_process_rules(process)
+
+    def can_read(self, key: str) -> bool:
+        if self._allow_all:
+            return True
+        if key in self._exact_keys:
+            return True
+        return any(key.startswith(prefix) for prefix in self._prefixes)
+
+    def read(self, key: str) -> tuple[str | None, str]:
+        if not self.can_read(key):
+            return None, "access_denied"
+        file = self._repo.get_file_by_key(key)
+        if file is None:
+            return None, "not_found"
+        version = self._repo.get_active_file_version(file.id)
+        if version is None:
+            return None, "not_found"
+        return version.content or "", "ok"
+
+    def list_readable_files(self, *, prefix: str | None = None, limit: int = 10_000) -> list[File]:
+        files = self._repo.list_files(prefix=prefix, limit=limit)
+        return [file for file in files if self.can_read(file.key)]
+
+    def _load_process_rules(self, process: Process) -> None:
+        pcs = self._repo.list_process_capabilities(process.id)
+        for pc in pcs:
+            cap = self._repo.get_capability(pc.capability)
+            if cap is None or not cap.enabled:
+                continue
+
+            cap_name = cap.name.split("/", 1)[0]
+            if cap_name not in {"file", "dir", "files"}:
+                continue
+
+            config = pc.config or {}
+            ops_raw = config.get("ops")
+            if ops_raw is not None:
+                ops = {str(op) for op in ops_raw}
+                if "read" not in ops:
+                    continue
+
+            key = config.get("key")
+            prefix = config.get("prefix")
+
+            if key:
+                self._exact_keys.add(str(key))
+                continue
+            if prefix:
+                self._prefixes.append(str(prefix))
+                continue
+
+            # Unscoped file/dir/files grant implies unrestricted prompt reads.
+            self._allow_all = True
 
 
 class ContextEngine:
-    """Resolves file includes into a single concatenated context string."""
+    """Resolve authored prompt text into a final system prompt."""
 
-    def __init__(self, file_store: FileStore) -> None:
-        self._store = file_store
+    def __init__(self, repo: Repository) -> None:
+        self._repo = repo
+        self._store = FileStore(repo)
 
     def resolve(self, key: str) -> str:
-        """Resolve a file by *key*, recursively expanding includes.
-
-        Returns the fully assembled context string.
-        Raises ``ValueError`` if the root file is not found.
-        """
         file = self._store.get(key)
         if file is None:
             raise ValueError(f"File not found: {key}")
-        return self._resolve_key(key, visited=set())
+        access = _FileAccessView(self._repo, None)
+        state = _ResolutionState(root_keys={key})
+        rendered = self._render_file(file, access, state, stack=(key,))
+        return self._compose_prompt([rendered], state.bundle_entries)
 
     def resolve_by_id(self, file_id: UUID) -> str:
-        """Resolve a file by *file_id*, recursively expanding includes.
-
-        Returns the fully assembled context string.
-        Raises ``ValueError`` if the root file is not found.
-        """
         file = self._store.get_by_id(file_id)
         if file is None:
             raise ValueError(f"File not found: {file_id}")
-        return self._resolve_key(file.key, visited=set())
+        return self.resolve(file.key)
 
     def generate_full_prompt(self, process: Process) -> str:
-        """Build the complete prompt for a process.
-
-        Resolves all attached files (with their includes) and prepends
-        them before ``process.content``.  This is the single source of
-        truth used by both the executor and the dashboard.
-        """
-        sections: list[str] = []
-        visited: set[str] = set()
-
-        # Resolve each attached file (process.files)
-        for fid in process.files or []:
-            file = self._store.get_by_id(fid)
-            if not file or file.key in visited:
-                continue
-            visited.add(file.key)
-            sections.append(self._resolve_key(file.key, visited=set(visited)))
-
-        # Legacy: single code FK (only if no files list)
-        if process.code and not process.files:
-            file = self._store.get_by_id(process.code)
-            if file and file.key not in visited:
-                visited.add(file.key)
-                sections.append(self._resolve_key(file.key, visited=set(visited)))
-
-        # Append process.content last
-        if process.content:
-            sections.append(f"--- content ---\n{process.content}")
-
-        return "\n\n".join(sections) if sections else ""
+        return self.resolve_prompt(process).text
 
     def resolve_prompt_tree(self, process: Process) -> list[dict]:
-        """Build a structured dependency tree for the process prompt.
+        return self.resolve_prompt(process).prompt_tree
 
-        Returns a list of dicts in include-order (deepest deps first):
-        ``[{"key": str, "content": str, "is_direct": bool}, ...]``
+    def resolve_prompt(self, process: Process) -> PromptResolution:
+        access = _FileAccessView(self._repo, process)
 
-        Each file appears at most once.  ``is_direct`` is True for files
-        explicitly attached to the process (i.e. in ``process.files``).
-        The final entry (if ``process.content`` is set) has
-        ``key = "<content>"`` and ``is_direct = True``.
-        """
-        result: list[dict] = []
-        seen: set[str] = set()
-        direct_keys: set[str] = set()
+        direct_files = self._direct_prompt_files(process)
+        global_files = access.list_readable_files(prefix=GLOBAL_INCLUDE_PREFIX)
 
-        # Collect direct file keys
-        for fid in process.files or []:
-            file = self._store.get_by_id(fid)
-            if file:
-                direct_keys.add(file.key)
+        root_entries: list[_PromptEntry] = []
+        root_keys = {file.key for file in direct_files}
+        root_keys.update(file.key for file in global_files)
+        state = _ResolutionState(root_keys=root_keys)
 
-        # Legacy code FK
-        if process.code and not process.files:
-            file = self._store.get_by_id(process.code)
-            if file:
-                direct_keys.add(file.key)
+        for file in global_files:
+            rendered = self._render_file(file, access, state, stack=(file.key,))
+            root_entries.append(_PromptEntry(key=file.key, content=rendered, is_direct=False))
 
-        # Resolve each direct file and its includes
-        for fid in process.files or []:
-            file = self._store.get_by_id(fid)
-            if not file or file.key in seen:
-                continue
-            self._collect_tree(file.key, seen, result, direct_keys)
+        for file in direct_files:
+            rendered = self._render_file(file, access, state, stack=(file.key,))
+            root_entries.append(_PromptEntry(key=file.key, content=rendered, is_direct=True))
 
-        if process.code and not process.files:
-            file = self._store.get_by_id(process.code)
-            if file and file.key not in seen:
-                self._collect_tree(file.key, seen, result, direct_keys)
-
-        # Append process.content last
         if process.content:
-            result.append({
-                "key": "<content>",
-                "content": process.content,
-                "is_direct": True,
-            })
+            rendered_content = self._render_text(process.content, access, state, stack=())
+            root_entries.append(_PromptEntry(key=CONTENT_KEY, content=rendered_content, is_direct=True))
 
-        return result
+        prompt_text = self._compose_prompt(
+            [entry.content for entry in root_entries if entry.content],
+            state.bundle_entries,
+        )
+        prompt_tree = [
+            {
+                "key": entry.key,
+                "content": entry.content,
+                "is_direct": entry.is_direct,
+            }
+            for entry in [*root_entries, *state.bundle_entries]
+        ]
+        return PromptResolution(text=prompt_text, prompt_tree=prompt_tree)
 
-    def _collect_tree(
+    def list_global_includes(self, process: Process) -> list[dict]:
+        access = _FileAccessView(self._repo, process)
+        includes: list[dict] = []
+        for file in access.list_readable_files(prefix=GLOBAL_INCLUDE_PREFIX):
+            content, status = access.read(file.key)
+            if status == "ok":
+                includes.append({"key": file.key, "content": content or ""})
+        return includes
+
+    def _direct_prompt_files(self, process: Process) -> list[File]:
+        direct_files: list[File] = []
+        seen: set[str] = set()
+
+        for file_id in process.files or []:
+            file = self._store.get_by_id(file_id)
+            if file is None or file.key in seen:
+                continue
+            seen.add(file.key)
+            direct_files.append(file)
+
+        if process.code and not process.files:
+            file = self._store.get_by_id(process.code)
+            if file is not None and file.key not in seen:
+                direct_files.append(file)
+
+        return direct_files
+
+    def _render_file(
         self,
-        key: str,
-        seen: set[str],
-        result: list[dict],
-        direct_keys: set[str],
-    ) -> None:
-        """Recursively collect files in dependency order (deps first)."""
-        if key in seen:
-            return
-        seen.add(key)
-
-        file = self._store.get(key)
-        if file is None:
-            result.append({"key": key, "content": f"[not found: {key}]", "is_direct": key in direct_keys})
-            return
-
-        # Resolve includes first (depth-first)
-        for include_key in file.includes:
-            self._collect_tree(include_key, seen, result, direct_keys)
-
-        content = self._store.get_content(key) or ""
-        result.append({"key": key, "content": content, "is_direct": key in direct_keys})
-
-    # ------------------------------------------------------------------
-    # Internal
-    # ------------------------------------------------------------------
-
-    def _resolve_key(self, key: str, *, visited: set[str]) -> str:
-        """Recursively resolve *key* and its includes.
-
-        *visited* tracks keys already seen on the current resolution path
-        to detect circular references.
-        """
-        if key in visited:
-            msg = f"[circular include: {key}]"
-            logger.warning("Circular include detected: %s", key)
-            return msg
-
-        visited.add(key)
-
-        file = self._store.get(key)
-        if file is None:
-            msg = f"[include not found: {key}]"
-            logger.warning("Included file not found: %s", key)
-            return msg
-
-        content = self._store.get_content(key) or ""
-
-        # Resolve includes depth-first, prepending them before main content.
+        file: File,
+        access: _FileAccessView,
+        state: _ResolutionState,
+        *,
+        stack: tuple[str, ...],
+    ) -> str:
         sections: list[str] = []
         for include_key in file.includes:
-            section = self._resolve_key(include_key, visited=set(visited))
-            sections.append(section)
+            marker = self._resolve_reference(include_key, access, state, stack=stack)
+            if marker:
+                sections.append(marker)
 
-        # Build the output with a header for the current file.
-        parts: list[str] = []
+        content, status = access.read(file.key)
+        if status == "not_found":
+            sections.append(self._not_found_marker(file.key))
+        else:
+            # Direct prompt files are explicit process configuration. They are still
+            # resolved recursively through scoped reads for nested dependencies.
+            file_content = content if status == "ok" else self._store.get_content(file.key) or ""
+            sections.append(self._render_text(file_content, access, state, stack=stack))
 
-        # Prepend resolved includes.
-        if sections:
-            parts.extend(sections)
+        return "\n\n".join(section for section in sections if section)
 
-        # Main content with a section header.
-        header = f"--- {key} ---"
-        parts.append(f"{header}\n{content}")
+    def _render_text(
+        self,
+        text: str,
+        access: _FileAccessView,
+        state: _ResolutionState,
+        *,
+        stack: tuple[str, ...],
+    ) -> str:
+        def replace(match: re.Match[str]) -> str:
+            return self._resolve_reference(match.group(1).strip(), access, state, stack=stack)
 
+        return INLINE_INCLUDE_RE.sub(replace, text)
+
+    def _resolve_reference(
+        self,
+        key: str,
+        access: _FileAccessView,
+        state: _ResolutionState,
+        *,
+        stack: tuple[str, ...],
+    ) -> str:
+        if not key:
+            return self._not_found_marker(key)
+        if key in stack:
+            return self._circular_marker(key)
+        if key in state.root_keys or key in state.emitted_bundle_keys:
+            return self._uses_marker(key)
+
+        content, status = access.read(key)
+        if status == "access_denied":
+            return self._access_denied_marker(key)
+        if status == "not_found":
+            return self._not_found_marker(key)
+
+        file = self._store.get(key)
+        if file is None:
+            return self._not_found_marker(key)
+
+        rendered = self._render_file(file, access, state, stack=(*stack, key))
+        state.bundle_entries.append(_PromptEntry(key=key, content=rendered, is_direct=False))
+        state.emitted_bundle_keys.add(key)
+        return self._uses_marker(key)
+
+    def _compose_prompt(self, sections: list[str], bundle_entries: list[_PromptEntry]) -> str:
+        bundle = [
+            f"{self._included_marker(entry.key)}\n{entry.content}"
+            for entry in bundle_entries
+        ]
+        parts = [part for part in [*sections, *bundle] if part]
         return "\n\n".join(parts)
+
+    @staticmethod
+    def _uses_marker(key: str) -> str:
+        return f"<!-- uses: {key} -->"
+
+    @staticmethod
+    def _included_marker(key: str) -> str:
+        return f"<!-- included: {key} -->"
+
+    @staticmethod
+    def _not_found_marker(key: str) -> str:
+        return f"<!-- include error: not found {key} -->"
+
+    @staticmethod
+    def _circular_marker(key: str) -> str:
+        return f"<!-- include error: circular {key} -->"
+
+    @staticmethod
+    def _access_denied_marker(key: str) -> str:
+        return f"<!-- include error: access denied {key} -->"

--- a/src/dashboard/routers/processes.py
+++ b/src/dashboard/routers/processes.py
@@ -11,7 +11,6 @@ from cogos.db.models import Handler, Process, ProcessMode, ProcessStatus
 from cogos.db.models.file import File, FileVersion
 from cogos.db.models.process_capability import ProcessCapability
 from cogos.files.context_engine import ContextEngine
-from cogos.files.store import FileStore
 from dashboard.db import get_repo
 
 logger = logging.getLogger(__name__)
@@ -345,10 +344,9 @@ def get_process(name: str, process_id: str) -> dict:
         for r in runs
     ]
 
-    # Resolve full prompt: file content + includes
-    ctx = ContextEngine(FileStore(repo))
-    resolved_prompt = ctx.generate_full_prompt(p)
-    prompt_tree = ctx.resolve_prompt_tree(p)
+    # Resolve full prompt using the same capability-scoped path as the executor.
+    ctx = ContextEngine(repo)
+    prompt_resolution = ctx.resolve_prompt(p)
 
     # Capabilities granted to this process (named grants with scope config)
     pcs = repo.list_process_capabilities(p.id)
@@ -370,14 +368,7 @@ def get_process(name: str, process_id: str) -> dict:
         if f:
             file_keys.append(f.key)
 
-    # Includes — files under "includes/" prefix
-    file_store = FileStore(repo)
-    include_files = file_store.list_files(prefix="includes/")
-    includes = []
-    for f in sorted(include_files, key=lambda f: f.key):
-        fv = repo.get_active_file_version(f.id)
-        if fv and fv.content:
-            includes.append({"key": f.key, "content": fv.content})
+    includes = ctx.list_global_includes(p)
 
     # Channel subscriptions (handlers)
     handlers = repo.list_handlers(process_id=p.id)
@@ -392,8 +383,8 @@ def get_process(name: str, process_id: str) -> dict:
     return {
         "process": _detail(p).model_dump(),
         "runs": run_list,
-        "resolved_prompt": resolved_prompt,
-        "prompt_tree": prompt_tree,
+        "resolved_prompt": prompt_resolution.text,
+        "prompt_tree": prompt_resolution.prompt_tree,
         "capabilities": [g["grant_name"] for g in cap_grants],
         "capability_configs": {
             g["grant_name"]: g["config"] or {}

--- a/src/dashboard/routers/runs.py
+++ b/src/dashboard/routers/runs.py
@@ -24,7 +24,7 @@ class RunSummary(BaseModel):
     process: str
     process_name: str | None = None
     runner: str | None = None
-    event: str | None = None
+    message: str | None = None
     conversation: str | None = None
     status: str
     tokens_in: int
@@ -40,7 +40,7 @@ class RunSummary(BaseModel):
 class RunDetail(BaseModel):
     id: str
     process: str
-    event: str | None = None
+    message: str | None = None
     conversation: str | None = None
     status: str
     tokens_in: int
@@ -169,7 +169,7 @@ def _summary(
         process=str(r.process),
         process_name=process_names.get(r.process) if process_names else None,
         runner=process_runners.get(r.process) if process_runners else None,
-        event=str(r.event) if r.event else None,
+        message=str(r.message) if r.message else None,
         conversation=str(r.conversation) if r.conversation else None,
         status=r.status.value,
         tokens_in=r.tokens_in,
@@ -187,7 +187,7 @@ def _detail(r: Run) -> RunDetail:
     return RunDetail(
         id=str(r.id),
         process=str(r.process),
-        event=str(r.event) if r.event else None,
+        message=str(r.message) if r.message else None,
         conversation=str(r.conversation) if r.conversation else None,
         status=r.status.value,
         tokens_in=r.tokens_in,

--- a/tests/cogos/local_validation.md
+++ b/tests/cogos/local_validation.md
@@ -118,6 +118,39 @@ cogent local cogos process run discord-handle-message --local
 - [ ] Runs and completes (no event payload, just executes the process prompt)
 - [ ] Prints token counts and duration
 
+## Filesystem Lab
+
+Boot the standard image, then load the filesystem-lab process templates on demand:
+
+```bash
+cogent local cogos process load images/cogent-v1/apps/filesystem-lab/respond.json
+```
+
+- [ ] Creates `filesystem-lab/respond`
+
+```bash
+cogent local cogos file get apps/filesystem-lab/prompts/respond.md
+```
+
+- [ ] Shows prompt source with inline `@{...}` references
+
+```bash
+cogent local cogos channel send filesystem-lab:requests --payload '{"task_key": "apps/filesystem-lab/fixtures/sample-task.md", "goal": "verify prompt resolution and file writes"}'
+cogent local cogos run-local --once
+```
+
+- [ ] `filesystem-lab/respond` runs locally
+- [ ] A report is written to `apps/filesystem-lab/output/latest-report.md`
+
+```bash
+cogent local cogos process load images/cogent-v1/apps/filesystem-lab/smoke.json
+cogent local cogos process run filesystem-lab/smoke --local
+cogent local cogos file get apps/filesystem-lab/output/smoke-report.md
+```
+
+- [ ] `filesystem-lab/smoke` writes the smoke report
+- [ ] Output mentions exact file keys that were inspected or written
+
 ## Process Lifecycle
 
 ```bash

--- a/tests/cogos/test_cli_process_load.py
+++ b/tests/cogos/test_cli_process_load.py
@@ -1,0 +1,40 @@
+import json
+
+from click.testing import CliRunner
+
+from cogos.cli.__main__ import cogos
+from cogos.db.local_repository import LocalRepository
+from cogos.db.models import Capability
+
+
+def test_process_load_preserves_multiple_capability_grants(tmp_path, monkeypatch):
+    monkeypatch.setenv("COGENT_LOCAL_DATA", str(tmp_path / "db"))
+
+    repo = LocalRepository(str(tmp_path / "db"))
+    for cap_name in ("dir", "me"):
+        repo.upsert_capability(
+            Capability(name=cap_name, handler="cogos.capabilities.files.FilesCapability")
+            if cap_name == "dir"
+            else Capability(name=cap_name, handler="cogos.capabilities.me.MeCapability")
+        )
+
+    proc_path = tmp_path / "processes.json"
+    proc_path.write_text(json.dumps([
+        {
+            "name": "test-proc",
+            "mode": "daemon",
+            "code_key": "missing.md",
+            "capabilities": ["dir", "me"],
+            "handlers": ["test:channel"],
+        }
+    ]))
+
+    runner = CliRunner()
+    result = runner.invoke(cogos, ["--cogent", "local", "process", "load", str(proc_path)])
+    assert result.exit_code == 0, result.output
+
+    repo = LocalRepository(str(tmp_path / "db"))
+    process = repo.get_process_by_name("test-proc")
+    grants = repo.list_process_capabilities(process.id)
+    assert {grant.name for grant in grants} == {"dir", "me"}
+

--- a/tests/cogos/test_executor_handler.py
+++ b/tests/cogos/test_executor_handler.py
@@ -1,7 +1,22 @@
 from uuid import uuid4
 
 from cogos.db.local_repository import LocalRepository
-from cogos.db.models import Channel, ChannelMessage, ChannelType, Delivery, DeliveryStatus, Handler, Process, ProcessMode, ProcessStatus, Run, RunStatus
+from cogos.db.models import (
+    Capability,
+    Channel,
+    ChannelMessage,
+    ChannelType,
+    Delivery,
+    DeliveryStatus,
+    Handler,
+    Process,
+    ProcessCapability,
+    ProcessMode,
+    ProcessStatus,
+    Run,
+    RunStatus,
+)
+from cogos.files.store import FileStore
 from cogos.executor import handler as executor_handler
 
 
@@ -228,7 +243,79 @@ def test_execute_process_rewrites_invalid_tool_names(monkeypatch, tmp_path):
     assert result.tokens_in == 24
     assert result.tokens_out == 12
     assert len(fake_bedrock.calls) == 2
+    assert fake_bedrock.calls[0]["messages"][0]["content"][0]["text"] == (
+        "Payload: {\n"
+        '  "content": "hello"\n'
+        "}\n"
+    )
     second_messages = fake_bedrock.calls[1]["messages"]
     assert second_messages[1]["content"][0]["toolUse"]["name"] == "search"
     assert second_messages[2]["content"][0]["toolResult"]["toolUseId"] == "tool-1"
     assert "invalid tool name 'bad tool'" in second_messages[2]["content"][0]["toolResult"]["content"][0]["text"]
+
+
+def test_execute_process_resolves_authored_includes_into_system_prompt(tmp_path):
+    repo = _repo(tmp_path)
+    files = FileStore(repo)
+    files.create("whoami/index", "You are the worker profile.")
+
+    dir_cap = Capability(name="dir", handler="cogos.capabilities.files.FilesCapability")
+    repo.upsert_capability(dir_cap)
+    dir_cap = repo.get_capability_by_name("dir")
+
+    process = Process(
+        name="worker",
+        mode=ProcessMode.ONE_SHOT,
+        status=ProcessStatus.RUNNING,
+        runner="lambda",
+        content="Handle the event.\n\n@{whoami/index}",
+    )
+    repo.upsert_process(process)
+    repo.create_process_capability(
+        ProcessCapability(
+            process=process.id,
+            capability=dir_cap.id,
+            name="dir",
+            config={"prefix": "whoami/", "ops": ["read"]},
+        )
+    )
+
+    run = Run(process=process.id, status=RunStatus.RUNNING)
+    config = executor_handler.ExecutorConfig(max_turns=1)
+
+    class FakeBedrock:
+        def __init__(self):
+            self.calls = []
+
+        def converse(self, **kwargs):
+            self.calls.append(kwargs)
+            return {
+                "output": {"message": {"role": "assistant", "content": [{"text": "done"}]}},
+                "usage": {"inputTokens": 3, "outputTokens": 2},
+                "stopReason": "end_turn",
+            }
+
+    fake_bedrock = FakeBedrock()
+
+    result = executor_handler.execute_process(
+        process,
+        {"event_type": "system:test", "payload": {"value": 1}},
+        run,
+        config,
+        repo,
+        bedrock_client=fake_bedrock,
+    )
+
+    assert result.tokens_in == 3
+    assert result.tokens_out == 2
+    assert len(fake_bedrock.calls) == 1
+    assert fake_bedrock.calls[0]["system"][0]["text"] == (
+        "Handle the event.\n\n"
+        "<!-- uses: whoami/index -->\n\n"
+        "<!-- included: whoami/index -->\n"
+        "You are the worker profile."
+    )
+    assert fake_bedrock.calls[0]["messages"][0]["content"][0]["text"] == (
+        "Event: system:test\n"
+        "Payload: {\n  \"value\": 1\n}\n"
+    )

--- a/tests/cogos/test_filesystem_lab_image.py
+++ b/tests/cogos/test_filesystem_lab_image.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import json
+
+from cogos.image.spec import load_image
+
+
+def test_cogent_v1_filesystem_lab_files_load():
+    spec = load_image(Path("images/cogent-v1"))
+    keys = {key for key in spec.files if key.startswith("apps/filesystem-lab/")}
+
+    assert "apps/filesystem-lab/prompts/respond.md" in keys
+    assert "apps/filesystem-lab/prompts/smoke.md" in keys
+    assert "apps/filesystem-lab/whoami.md" in keys
+    assert "apps/filesystem-lab/fixtures/sample-task.md" in keys
+    assert "apps/filesystem-lab/playbooks/operating-rules.md" in keys
+    assert "apps/filesystem-lab/playbooks/report-format.md" in keys
+    assert "apps/filesystem-lab/playbooks/shared-style.md" in keys
+
+
+def test_cogent_v1_filesystem_lab_prompt_includes():
+    spec = load_image(Path("images/cogent-v1"))
+
+    assert spec.file_includes["apps/filesystem-lab/prompts/respond.md"] == [
+        "apps/filesystem-lab/whoami.md",
+    ]
+    assert spec.file_includes["apps/filesystem-lab/prompts/smoke.md"] == [
+        "apps/filesystem-lab/whoami.md",
+    ]
+
+    respond_prompt = spec.files["apps/filesystem-lab/prompts/respond.md"]
+    assert "@{apps/filesystem-lab/playbooks/operating-rules.md}" in respond_prompt
+    assert "@{apps/filesystem-lab/playbooks/report-format.md}" in respond_prompt
+
+    operating_rules = spec.files["apps/filesystem-lab/playbooks/operating-rules.md"]
+    report_format = spec.files["apps/filesystem-lab/playbooks/report-format.md"]
+    assert "@{apps/filesystem-lab/playbooks/shared-style.md}" in operating_rules
+    assert "@{apps/filesystem-lab/playbooks/shared-style.md}" in report_format
+
+
+def test_filesystem_lab_process_templates_exist():
+    process_defs_path = Path("images/cogent-v1/apps/filesystem-lab/processes.json")
+    entries = json.loads(process_defs_path.read_text())
+
+    names = {entry["name"] for entry in entries}
+    assert names == {"filesystem-lab/respond", "filesystem-lab/smoke"}
+
+    respond = next(entry for entry in entries if entry["name"] == "filesystem-lab/respond")
+    assert respond["code_key"] == "apps/filesystem-lab/prompts/respond.md"
+    assert respond["handlers"] == ["filesystem-lab:requests"]
+    assert respond["capabilities"] == ["dir", "me"]
+
+    smoke = next(entry for entry in entries if entry["name"] == "filesystem-lab/smoke")
+    assert smoke["code_key"] == "apps/filesystem-lab/prompts/smoke.md"
+    assert smoke["handlers"] == []
+
+    respond_only = json.loads(Path("images/cogent-v1/apps/filesystem-lab/respond.json").read_text())
+    smoke_only = json.loads(Path("images/cogent-v1/apps/filesystem-lab/smoke.json").read_text())
+    assert respond_only[0]["name"] == "filesystem-lab/respond"
+    assert smoke_only[0]["name"] == "filesystem-lab/smoke"

--- a/tests/cogos/test_prompt_context_engine.py
+++ b/tests/cogos/test_prompt_context_engine.py
@@ -1,0 +1,123 @@
+from uuid import uuid4
+
+from cogos.db.local_repository import LocalRepository
+from cogos.db.models import Capability, Process, ProcessCapability
+from cogos.files.context_engine import ContextEngine
+from cogos.files.store import FileStore
+
+
+def _repo(tmp_path) -> LocalRepository:
+    return LocalRepository(str(tmp_path))
+
+
+def _upsert_capability(repo: LocalRepository, name: str) -> Capability:
+    cap = repo.get_capability_by_name(name)
+    if cap is not None:
+        return cap
+    cap = Capability(name=name, handler="cogos.capabilities.files.FilesCapability")
+    repo.upsert_capability(cap)
+    return repo.get_capability_by_name(name)
+
+
+def _grant(repo: LocalRepository, process: Process, cap_name: str, *, config: dict | None = None) -> None:
+    cap = _upsert_capability(repo, cap_name)
+    repo.create_process_capability(
+        ProcessCapability(
+            process=process.id,
+            capability=cap.id,
+            name=f"{cap_name}-{uuid4()}",
+            config=config,
+        )
+    )
+
+
+def _put_file(repo: LocalRepository, key: str, content: str, *, includes: list[str] | None = None) -> None:
+    FileStore(repo).create(key, content, includes=includes)
+
+
+def test_inline_includes_render_markers_and_deduped_bundle(tmp_path):
+    repo = _repo(tmp_path)
+    _put_file(repo, "whoami/index", "You are Acme support. Be brief, direct, and accurate.")
+    _put_file(
+        repo,
+        "playbooks/refunds",
+        "Refunds under $100 can be approved immediately.\nFor larger refunds:\n@{playbooks/escalation}",
+    )
+    _put_file(
+        repo,
+        "playbooks/escalation",
+        "Ask for the order ID and explain that a human reviewer will follow up.",
+    )
+
+    process = Process(
+        name="support",
+        content="Handle inbound support messages.\n\n@{whoami/index}\n\nWhen the message is about billing:\n@{playbooks/refunds}",
+    )
+    repo.upsert_process(process)
+    _grant(repo, process, "file", config={"key": "whoami/index", "ops": ["read"]})
+    _grant(repo, process, "dir", config={"prefix": "playbooks/", "ops": ["read"]})
+
+    prompt = ContextEngine(repo).generate_full_prompt(process)
+
+    assert prompt == (
+        "Handle inbound support messages.\n\n"
+        "<!-- uses: whoami/index -->\n\n"
+        "When the message is about billing:\n"
+        "<!-- uses: playbooks/refunds -->\n\n"
+        "<!-- included: whoami/index -->\n"
+        "You are Acme support. Be brief, direct, and accurate.\n\n"
+        "<!-- included: playbooks/escalation -->\n"
+        "Ask for the order ID and explain that a human reviewer will follow up.\n\n"
+        "<!-- included: playbooks/refunds -->\n"
+        "Refunds under $100 can be approved immediately.\n"
+        "For larger refunds:\n"
+        "<!-- uses: playbooks/escalation -->"
+    )
+
+
+def test_access_denied_inline_include_renders_in_place_error(tmp_path):
+    repo = _repo(tmp_path)
+    _put_file(repo, "whoami/index", "secret")
+
+    process = Process(name="limited", content="Top secret? @{whoami/index}")
+    repo.upsert_process(process)
+    _grant(repo, process, "dir", config={"prefix": "workspace/", "ops": ["read"]})
+
+    prompt = ContextEngine(repo).generate_full_prompt(process)
+
+    assert prompt == "Top secret? <!-- include error: access denied whoami/index -->"
+
+
+def test_legacy_file_metadata_includes_use_same_bundle_resolution(tmp_path):
+    repo = _repo(tmp_path)
+    _put_file(repo, "playbooks/refunds", "Refund flow")
+    store = FileStore(repo)
+    main = store.create("prompts/main", "Use the latest refund playbook.", includes=["playbooks/refunds"])
+
+    process = Process(name="legacy", files=[main.id])
+    repo.upsert_process(process)
+    _grant(repo, process, "dir", config={"prefix": "playbooks/", "ops": ["read"]})
+
+    prompt = ContextEngine(repo).generate_full_prompt(process)
+
+    assert prompt == (
+        "<!-- uses: playbooks/refunds -->\n\n"
+        "Use the latest refund playbook.\n\n"
+        "<!-- included: playbooks/refunds -->\n"
+        "Refund flow"
+    )
+
+
+def test_global_include_files_only_apply_when_process_can_read_them(tmp_path):
+    repo = _repo(tmp_path)
+    _put_file(repo, "cogos/includes/code_mode", "You may write Python when needed.")
+
+    process = Process(name="worker", content="Handle the job.")
+    repo.upsert_process(process)
+
+    prompt_without_grant = ContextEngine(repo).generate_full_prompt(process)
+    assert prompt_without_grant == "Handle the job."
+
+    _grant(repo, process, "dir", config={"prefix": "cogos/includes/", "ops": ["read"]})
+    prompt_with_grant = ContextEngine(repo).generate_full_prompt(process)
+    assert prompt_with_grant == "You may write Python when needed.\n\nHandle the job."

--- a/tests/dashboard/test_process_prompt_resolution.py
+++ b/tests/dashboard/test_process_prompt_resolution.py
@@ -1,0 +1,50 @@
+from fastapi.testclient import TestClient
+
+from cogos.db.local_repository import LocalRepository
+from cogos.db.models import Capability, Process, ProcessCapability
+from cogos.files.store import FileStore
+from dashboard.app import create_app
+
+
+def test_process_detail_uses_scoped_prompt_resolution(tmp_path, monkeypatch):
+    repo = LocalRepository(str(tmp_path))
+    files = FileStore(repo)
+    files.create("playbooks/refunds", "Refunds require context from @{playbooks/escalation}")
+    files.create("playbooks/escalation", "Escalate to finance.")
+    files.create("cogos/includes/code_mode", "Code mode guidance.")
+
+    dir_cap = Capability(name="dir", handler="cogos.capabilities.files.FilesCapability")
+    repo.upsert_capability(dir_cap)
+    dir_cap = repo.get_capability_by_name("dir")
+
+    process = Process(name="support", content="Use @{playbooks/refunds}")
+    repo.upsert_process(process)
+    repo.create_process_capability(
+        ProcessCapability(
+            process=process.id,
+            capability=dir_cap.id,
+            name="dir",
+            config={"prefix": "playbooks/", "ops": ["read"]},
+        )
+    )
+
+    monkeypatch.setattr("dashboard.routers.processes.get_repo", lambda: repo)
+    client = TestClient(create_app())
+
+    resp = client.get(f"/api/cogents/test/processes/{process.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["resolved_prompt"] == (
+        "Use <!-- uses: playbooks/refunds -->\n\n"
+        "<!-- included: playbooks/escalation -->\n"
+        "Escalate to finance.\n\n"
+        "<!-- included: playbooks/refunds -->\n"
+        "Refunds require context from <!-- uses: playbooks/escalation -->"
+    )
+    assert data["includes"] == []
+    assert data["prompt_tree"][-1] == {
+        "key": "playbooks/refunds",
+        "content": "Refunds require context from <!-- uses: playbooks/escalation -->",
+        "is_direct": False,
+    }

--- a/tests/dashboard/test_runs_router.py
+++ b/tests/dashboard/test_runs_router.py
@@ -1,0 +1,27 @@
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from cogos.db.local_repository import LocalRepository
+from cogos.db.models import Process, Run, RunStatus
+from dashboard.app import create_app
+
+
+def test_runs_endpoint_supports_message_backed_runs(tmp_path, monkeypatch):
+    repo = LocalRepository(str(tmp_path))
+    process = Process(name="worker")
+    repo.upsert_process(process)
+
+    run = Run(process=process.id, message=uuid4(), status=RunStatus.COMPLETED, tokens_in=5, tokens_out=7)
+    repo.create_run(run)
+
+    monkeypatch.setattr("dashboard.routers.runs.get_repo", lambda: repo)
+    client = TestClient(create_app())
+
+    resp = client.get("/api/cogents/test/runs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["runs"][0]["id"] == str(run.id)
+    assert data["runs"][0]["message"] == str(run.message)
+    assert data["runs"][0]["process_name"] == "worker"


### PR DESCRIPTION
## Problem
This flow could resolve authored `@{file}` references in different ways depending on whether you looked at the dashboard preview or the executor runtime, so operators had no reliable way to inspect the exact prompt the model would receive.

The new filesystem-lab local validation path also still targeted the wrong behavior in two places: `process load` collapsed named capability grants like `dir` and `me`, and the Runs API still read `Run.event`, so the local flow could lose file access and the Runs tab could 500 even when the CLI showed completed runs.

## Summary
- resolve authored prompt includes through the shared context engine in both the executor and dashboard process detail flow
- add prompt-source insertion and resolved prompt preview support in the dashboard editors
- add the filesystem-lab image files, process templates, validation doc steps, and regression coverage for image loading and CLI process loading
- preserve capability grant names during `process load` and switch the Runs API to `Run.message` so filesystem-lab runs retain `dir` and `me` access and show up correctly in the dashboard

## Testing
- `uv run pytest tests/cogos/test_prompt_context_engine.py tests/cogos/test_executor_handler.py tests/dashboard/test_process_prompt_resolution.py tests/cogos/test_cli_process_load.py tests/cogos/test_filesystem_lab_image.py tests/dashboard/test_runs_router.py tests/cogos/test_local_executor.py -q`
- `cd dashboard/frontend && npm run type-check`
- `cd dashboard/frontend && npm run build`
