### PR TITLE
feat(dashboard): explain prompt composition in the process editor

### DIFF
--- a/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
+++ b/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
 import type { CogosProcess, CogosProcessRun, Resource, CogosRun, CogosFile, CogosCapability, EventType } from "@/lib/types";
 import { Badge } from "@/components/shared/Badge";
+import { InfoTooltip } from "@/components/shared/InfoTooltip";
 import { JsonViewer } from "@/components/shared/JsonViewer";
 import { PromptTextarea } from "@/components/shared/PromptTextarea";
 import type { CogosFileVersion } from "@/lib/types";
@@ -167,6 +169,18 @@ function filterPromptSuggestions(allKeys: string[], grants: CapGrant[]): string[
   return allKeys.filter((key) => fileGrants.some((grant) => grantAllowsPromptRead(grant, key)));
 }
 
+function SectionHelp({ title, bullets }: { title: string; bullets: string[] }) {
+  return (
+    <InfoTooltip title={title}>
+      <ul className="m-0 pl-4 space-y-1">
+        {bullets.map((bullet) => (
+          <li key={bullet}>{bullet}</li>
+        ))}
+      </ul>
+    </InfoTooltip>
+  );
+}
+
 /* ── TagListEditor: editable list with typeahead ── */
 
 function TagListEditor({
@@ -296,10 +310,12 @@ function FileGrantEditor({
   grants,
   onChange,
   processName,
+  help,
 }: {
   grants: CapGrant[];
   onChange: (grants: CapGrant[]) => void;
   processName: string;
+  help?: ReactNode;
 }) {
   const [addType, setAddType] = useState<"file" | "dir" | null>(null);
   const [addName, setAddName] = useState("");
@@ -350,7 +366,10 @@ function FileGrantEditor({
 
   return (
     <div>
-      <label className="text-[10px] text-[var(--text-muted)] uppercase block mb-1">Files & Directories</label>
+      <div className="flex items-center gap-2 mb-1">
+        <label className="text-[10px] text-[var(--text-muted)] uppercase">Files & Directories</label>
+        {help}
+      </div>
       {fileGrants.length > 0 && (
         <div className="space-y-1 mb-1">
           {fileGrants.map((g) => {
@@ -1673,6 +1692,14 @@ function ProcessFormEditor({
       <div>
         <div className="flex items-center gap-2 mb-1">
           <label className="text-[10px] text-[var(--text-muted)] uppercase">Prompt Files</label>
+          <SectionHelp
+            title="1. Prompt Files"
+            bullets={[
+              "Whole files attached to the process as prompt roots.",
+              "Their contents become part of the system prompt.",
+              "Attached files are explicit roots; nested @{...} references still use readable file access.",
+            ]}
+          />
         </div>
         {((includes && includes.length > 0) || form.files.length > 0) && (
           <div className="rounded overflow-hidden mb-1" style={{ border: "1px solid var(--border)" }}>
@@ -1817,7 +1844,17 @@ function ProcessFormEditor({
 
       {/* Prompt source */}
       <div>
-        <label className="text-[10px] text-[var(--text-muted)] uppercase block mb-1">Prompt Source</label>
+        <div className="flex items-center gap-2 mb-1">
+          <label className="text-[10px] text-[var(--text-muted)] uppercase">Prompt Source</label>
+          <SectionHelp
+            title="2. Prompt Source"
+            bullets={[
+              "Inline instructions stored on the process itself.",
+              "Also becomes part of the system prompt.",
+              "Can reference readable files with @{file-key}.",
+            ]}
+          />
+        </div>
         <PromptTextarea
           className={INPUT_CLS}
           rows={4}
@@ -1834,6 +1871,16 @@ function ProcessFormEditor({
         grants={form.grants}
         onChange={(grants) => onChange((prev) => ({ ...prev, grants }))}
         processName={form.name}
+        help={(
+          <SectionHelp
+            title="3. Files & Directories"
+            bullets={[
+              "Runtime file access grants, not prompt content.",
+              "Controls what the process can read or write through capabilities.",
+              "Also controls which files are valid for prompt-reference suggestions and nested includes.",
+            ]}
+          />
+        )}
       />
 
       {/* Other Capabilities (file/dir shown above) */}

--- a/dashboard/frontend/src/components/shared/InfoTooltip.tsx
+++ b/dashboard/frontend/src/components/shared/InfoTooltip.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface InfoTooltipProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function InfoTooltip({ title, children }: InfoTooltipProps) {
+  return (
+    <span className="relative inline-flex items-center group align-middle">
+      <button
+        type="button"
+        aria-label={`${title} help`}
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px] font-semibold cursor-help"
+        style={{
+          borderColor: "var(--border)",
+          color: "var(--text-muted)",
+          background: "var(--bg-surface)",
+        }}
+      >
+        i
+      </button>
+      <span
+        className="pointer-events-none absolute left-0 top-full z-50 mt-1 hidden w-72 rounded-md border px-3 py-2 group-hover:block group-focus-within:block"
+        style={{
+          borderColor: "var(--border)",
+          background: "var(--bg-elevated)",
+          boxShadow: "0 8px 20px rgba(0,0,0,0.35)",
+        }}
+      >
+        <span
+          className="block text-[10px] font-semibold uppercase tracking-wide"
+          style={{ color: "var(--text-primary)" }}
+        >
+          {title}
+        </span>
+        <span className="mt-2 block text-[10px]" style={{ color: "var(--text-secondary)" }}>
+          {children}
+        </span>
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Problem
The process editor exposed three separate prompt and file sections with no inline explanation of how they differed.

That made the product model hard to learn: attached prompt files, inline prompt source, and file access grants looked adjacent in the UI but served different roles during prompt assembly and execution.

## Summary
- add a reusable `(i)` hover tooltip component for short inline dashboard help
- explain `1. Prompt Files` as explicit prompt roots attached to the process
- explain `2. Prompt Source` as inline authored instructions that can also reference readable files
- explain `3. Files & Directories` as runtime access grants that control file capability scope, prompt-reference suggestions, and nested include resolution

## Testing
- `cd dashboard/frontend && npm run type-check`
- `cd dashboard/frontend && npm run build`
