### PR TITLE
Fix prompt file-reference typeahead in files and process editors

### DIFF
--- a/dashboard/frontend/src/components/files/FilesPanel.tsx
+++ b/dashboard/frontend/src/components/files/FilesPanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import type { CogosFile, CogosFileVersion } from "@/lib/types";
 import { Badge } from "@/components/shared/Badge";
 import { HierarchyPanel, findNode, getAllItems, buildTree } from "@/components/shared/HierarchyPanel";
+import { FileReferenceTextarea } from "@/components/shared/FileReferenceTextarea";
 import { fmtTimestamp } from "@/lib/format";
 import {
   getFileDetail,
@@ -25,197 +26,6 @@ const getFileGroup = (item: CogosFile) => {
   const parts = item.key.split("/");
   return parts.length > 1 ? parts.slice(0, -1).join("/") : "(root)";
 };
-
-const FILE_REFERENCE_TRIGGER = "@{";
-
-function extractReferencedFiles(content: string, excludeKey?: string) {
-  const seen = new Set<string>();
-  const refs: string[] = [];
-  for (const match of content.matchAll(/@\{([^}\r\n]+)\}/g)) {
-    const key = match[1]?.trim();
-    if (!key || key === excludeKey || seen.has(key)) continue;
-    seen.add(key);
-    refs.push(key);
-  }
-  return refs;
-}
-
-function getActiveReference(
-  value: string,
-  caret: number,
-): { start: number; end: number; query: string } | null {
-  const triggerStart = value.lastIndexOf(FILE_REFERENCE_TRIGGER, caret);
-  if (triggerStart === -1) return null;
-
-  const between = value.slice(triggerStart + FILE_REFERENCE_TRIGGER.length, caret);
-  if (!between && value.slice(triggerStart, caret) !== FILE_REFERENCE_TRIGGER) {
-    return null;
-  }
-  if (between.includes("}") || /\s/.test(between)) return null;
-
-  const closingIndex = value.indexOf("}", triggerStart + FILE_REFERENCE_TRIGGER.length);
-  if (closingIndex !== -1 && closingIndex < caret) return null;
-
-  return {
-    start: triggerStart,
-    end: closingIndex === -1 ? caret : closingIndex + 1,
-    query: between,
-  };
-}
-
-interface FileReferenceTextareaProps {
-  value: string;
-  onChange: (value: string) => void;
-  suggestions: string[];
-  currentKey?: string;
-  placeholder: string;
-  rows: number;
-}
-
-function FileReferenceTextarea({
-  value,
-  onChange,
-  suggestions,
-  currentKey,
-  placeholder,
-  rows,
-}: FileReferenceTextareaProps) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [activeReference, setActiveReference] = useState<{ start: number; end: number; query: string } | null>(null);
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
-
-  const referencedFiles = useMemo(
-    () => extractReferencedFiles(value, currentKey),
-    [value, currentKey],
-  );
-
-  const filteredSuggestions = useMemo(() => {
-    if (!activeReference) return [];
-    const query = activeReference.query.trim().toLowerCase();
-    return suggestions
-      .filter((key) => key !== currentKey)
-      .filter((key) => !query || key.toLowerCase().includes(query))
-      .slice(0, 8);
-  }, [activeReference, currentKey, suggestions]);
-
-  const refreshActiveReference = useCallback(() => {
-    const textarea = textareaRef.current;
-    if (!textarea || textarea.selectionStart !== textarea.selectionEnd) {
-      setActiveReference(null);
-      return;
-    }
-    setActiveReference(getActiveReference(textarea.value, textarea.selectionStart));
-  }, []);
-
-  const applySuggestion = useCallback((suggestion: string) => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    const currentValue = textarea.value;
-    const nextActive = getActiveReference(currentValue, textarea.selectionStart);
-    if (!nextActive) return;
-
-    const nextValue = `${currentValue.slice(0, nextActive.start)}@{${suggestion}}${currentValue.slice(nextActive.end)}`;
-    const nextCaret = nextActive.start + suggestion.length + 3;
-    onChange(nextValue);
-
-    requestAnimationFrame(() => {
-      const nextTextarea = textareaRef.current;
-      if (!nextTextarea) return;
-      nextTextarea.focus();
-      nextTextarea.setSelectionRange(nextCaret, nextCaret);
-      setActiveReference(getActiveReference(nextValue, nextCaret));
-    });
-  }, [onChange]);
-
-  useEffect(() => {
-    setHighlightedIndex(0);
-  }, [filteredSuggestions]);
-
-  return (
-    <div className="relative">
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => {
-          onChange(e.target.value);
-          requestAnimationFrame(refreshActiveReference);
-        }}
-        onClick={refreshActiveReference}
-        onFocus={refreshActiveReference}
-        onKeyUp={refreshActiveReference}
-        onSelect={refreshActiveReference}
-        onBlur={() => {
-          setTimeout(() => setActiveReference(null), 0);
-        }}
-        onKeyDown={(e) => {
-          if (!activeReference || filteredSuggestions.length === 0) return;
-
-          if (e.key === "ArrowDown") {
-            e.preventDefault();
-            setHighlightedIndex((idx) => (idx + 1) % filteredSuggestions.length);
-            return;
-          }
-          if (e.key === "ArrowUp") {
-            e.preventDefault();
-            setHighlightedIndex((idx) => (idx - 1 + filteredSuggestions.length) % filteredSuggestions.length);
-            return;
-          }
-          if (e.key === "Enter" || e.key === "Tab") {
-            e.preventDefault();
-            applySuggestion(filteredSuggestions[highlightedIndex] ?? filteredSuggestions[0]);
-            return;
-          }
-          if (e.key === "Escape") {
-            setActiveReference(null);
-          }
-        }}
-        placeholder={placeholder}
-        rows={rows}
-        className="w-full px-2 py-1.5 text-[12px] rounded border font-mono resize-y"
-        style={inputStyle}
-      />
-      {activeReference && filteredSuggestions.length > 0 && (
-        <div
-          className="absolute left-0 right-0 mt-1 rounded-md overflow-hidden z-30"
-          style={{
-            background: "var(--bg-elevated)",
-            border: "1px solid var(--border)",
-            boxShadow: "0 10px 30px rgba(0,0,0,0.18)",
-            maxHeight: "180px",
-            overflowY: "auto",
-          }}
-        >
-          {filteredSuggestions.map((suggestion, index) => (
-            <button
-              key={suggestion}
-              type="button"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                applySuggestion(suggestion);
-              }}
-              className="w-full text-left px-2 py-1.5 border-0 font-mono text-[11px] cursor-pointer"
-              style={{
-                background: index === highlightedIndex ? "var(--bg-hover)" : "transparent",
-                color: index === highlightedIndex ? "var(--accent)" : "var(--text-secondary)",
-              }}
-            >
-              {suggestion}
-            </button>
-          ))}
-        </div>
-      )}
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[9px] text-[var(--text-muted)]">
-        <span>Type <span className="font-mono">@{"{"}</span> to reference another file.</span>
-        {referencedFiles.length > 0 && (
-          <span className="font-mono">
-            refs: {referencedFiles.join(", ")}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
 
 /* ── Version detail panel (inline below file list) ── */
 
@@ -507,6 +317,9 @@ function VersionPanel({ file, fileSuggestions, cogentName, canMutate, onRefresh,
                     currentKey={file.key}
                     placeholder="File content..."
                     rows={12}
+                    className="w-full px-2 py-1.5 text-[12px] rounded border font-mono resize-y"
+                    style={inputStyle}
+                    helperText="Type @{ to reference another file."
                   />
                   <div className="flex gap-1.5 items-center flex-wrap">
                     {saveConfirm === "update" ? (
@@ -663,6 +476,9 @@ export function FilesPanel({ files, cogentName, onRefresh }: FilesPanelProps) {
               currentKey={newKey.trim() || undefined}
               placeholder="File content..."
               rows={5}
+              className="w-full px-2 py-1.5 text-[12px] rounded border font-mono resize-y"
+              style={inputStyle}
+              helperText="Type @{ to reference another file."
             />
           </div>
           <div className="flex gap-2">

--- a/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
+++ b/dashboard/frontend/src/components/processes/ProcessesPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 import type { CogosProcess, CogosProcessRun, Resource, CogosRun, CogosFile, CogosCapability, EventType } from "@/lib/types";
 import { Badge } from "@/components/shared/Badge";
+import { FileReferenceTextarea } from "@/components/shared/FileReferenceTextarea";
 import { InfoTooltip } from "@/components/shared/InfoTooltip";
 import { JsonViewer } from "@/components/shared/JsonViewer";
 import type { CogosFileVersion } from "@/lib/types";
@@ -158,6 +159,46 @@ function SectionHelp({ title, bullets }: { title: string; bullets: string[] }) {
       </ul>
     </InfoTooltip>
   );
+}
+
+function grantAllowsRead(config: Record<string, unknown> | null): boolean {
+  const ops = config?.ops;
+  return !Array.isArray(ops) || ops.includes("read");
+}
+
+function getPromptReferenceSuggestions(fileKeys: string[], grants: CapGrant[]): string[] {
+  const sortedKeys = [...fileKeys].sort((a, b) => a.localeCompare(b));
+  const suggestions: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (key: string) => {
+    if (!seen.has(key)) {
+      seen.add(key);
+      suggestions.push(key);
+    }
+  };
+
+  for (const grant of grants) {
+    if (!grantAllowsRead(grant.config)) continue;
+
+    const config = (grant.config || {}) as Record<string, unknown>;
+    if (grant.capability_name === "file") {
+      const key = typeof config.key === "string" ? config.key : "";
+      if (!key) return sortedKeys;
+      if (sortedKeys.includes(key)) add(key);
+      continue;
+    }
+
+    if (grant.capability_name === "dir" || grant.capability_name === "files") {
+      const prefix = typeof config.prefix === "string" ? config.prefix : "";
+      if (!prefix) return sortedKeys;
+      for (const key of sortedKeys) {
+        if (key.startsWith(prefix)) add(key);
+      }
+    }
+  }
+
+  return suggestions;
 }
 /* ── TagListEditor: editable list with typeahead ── */
 
@@ -1313,11 +1354,13 @@ function DurationUnitMenu({ value, onChange }: { value: DurationUnit; onChange: 
 
 function InlineFileEditor({
   fileKey,
+  fileSuggestions,
   cogentName,
   onRefresh,
   onClose,
 }: {
   fileKey: string;
+  fileSuggestions: string[];
   cogentName: string;
   onRefresh?: () => void;
   onClose: () => void;
@@ -1468,12 +1511,16 @@ function InlineFileEditor({
       {currentVersion && (
         editing ? (
           <div className="px-2 py-1.5 space-y-1.5">
-            <textarea
+            <FileReferenceTextarea
               value={editContent}
-              onChange={(e) => { setEditContent(e.target.value); setSaveConfirm(null); }}
+              onChange={(value) => { setEditContent(value); setSaveConfirm(null); }}
+              suggestions={fileSuggestions}
+              currentKey={fileKey}
+              placeholder="File content..."
               rows={8}
               className="w-full px-2 py-1 text-[11px] rounded border font-mono resize-y"
               style={{ background: "var(--bg-base)", borderColor: "var(--border)", color: "var(--text-primary)" }}
+              helperText="Type @{ to reference another file."
             />
             <div className="flex gap-1.5 items-center flex-wrap">
               {saveConfirm === "update" ? (
@@ -1532,6 +1579,7 @@ function ProcessFormEditor({
   isNew,
   resourceSuggestions,
   fileSuggestions,
+  promptReferenceSuggestions,
   capabilitySuggestions,
   eventTypeSuggestions,
   cogentName,
@@ -1547,6 +1595,7 @@ function ProcessFormEditor({
   isNew: boolean;
   resourceSuggestions: string[];
   fileSuggestions: string[];
+  promptReferenceSuggestions: string[];
   capabilitySuggestions: string[];
   eventTypeSuggestions: string[];
   cogentName: string;
@@ -1698,6 +1747,7 @@ function ProcessFormEditor({
                   {isExpanded && (
                     <InlineFileEditor
                       fileKey={inc.key}
+                      fileSuggestions={fileSuggestions}
                       cogentName={cogentName}
                       onRefresh={onRefresh}
                       onClose={() => setExpandedEditFiles((prev) => { const next = new Set(prev); next.delete(inc.key); return next; })}
@@ -1787,6 +1837,7 @@ function ProcessFormEditor({
                   {isExpanded && (
                     <InlineFileEditor
                       fileKey={fileKey}
+                      fileSuggestions={fileSuggestions}
                       cogentName={cogentName}
                       onRefresh={onRefresh}
                       onClose={() => setExpandedEditFiles((prev) => { const next = new Set(prev); next.delete(fileKey); return next; })}
@@ -1825,11 +1876,14 @@ function ProcessFormEditor({
             ]}
           />
         </div>
-        <textarea
+        <FileReferenceTextarea
           className={INPUT_CLS}
           rows={4}
           value={form.content}
-          onChange={(e) => onChange({ ...form, content: e.target.value })}
+          onChange={(value) => onChange({ ...form, content: value })}
+          suggestions={promptReferenceSuggestions}
+          placeholder="Add process instructions..."
+          helperText="Type @{ to reference a readable file."
           style={{ resize: "vertical" }}
         />
       </div>
@@ -1944,6 +1998,10 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
 
   const resourceSuggestions = useMemo(() => resources.map((r) => r.name), [resources]);
   const fileSuggestions = useMemo(() => files.map((f) => f.key), [files]);
+  const promptReferenceSuggestions = useMemo(
+    () => getPromptReferenceSuggestions(fileSuggestions, form.grants),
+    [fileSuggestions, form.grants],
+  );
   const capabilitySuggestions = useMemo(() => capabilities.map((c) => c.name), [capabilities]);
   const eventTypeSuggestions = useMemo(() => eventTypes.map((et) => et.name), [eventTypes]);
 
@@ -2138,6 +2196,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
             isNew
             resourceSuggestions={resourceSuggestions}
             fileSuggestions={fileSuggestions}
+            promptReferenceSuggestions={promptReferenceSuggestions}
             capabilitySuggestions={capabilitySuggestions}
             eventTypeSuggestions={eventTypeSuggestions}
             cogentName={cogentName}
@@ -2333,6 +2392,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                                 isFileEditing ? (
                                   <InlineFileEditor
                                     fileKey={entry.key}
+                                    fileSuggestions={fileSuggestions}
                                     cogentName={cogentName}
                                     onRefresh={async () => { onRefresh(); await fetchDetail(proc.id, { preserveExpanded: true }); }}
                                     onClose={() => setEditingFileKey(null)}
@@ -2569,6 +2629,7 @@ export function ProcessesPanel({ processes, cogentName, onRefresh, resources, ru
                     isNew={false}
                     resourceSuggestions={resourceSuggestions}
                     fileSuggestions={fileSuggestions}
+                    promptReferenceSuggestions={promptReferenceSuggestions}
                     capabilitySuggestions={capabilitySuggestions}
                     eventTypeSuggestions={eventTypeSuggestions}
                     cogentName={cogentName}

--- a/dashboard/frontend/src/components/shared/FileReferenceTextarea.tsx
+++ b/dashboard/frontend/src/components/shared/FileReferenceTextarea.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import type { CSSProperties } from "react";
+
+const FILE_REFERENCE_TRIGGER = "@{";
+
+function extractReferencedFiles(content: string, excludeKey?: string) {
+  const seen = new Set<string>();
+  const refs: string[] = [];
+  for (const match of content.matchAll(/@\{([^}\r\n]+)\}/g)) {
+    const key = match[1]?.trim();
+    if (!key || key === excludeKey || seen.has(key)) continue;
+    seen.add(key);
+    refs.push(key);
+  }
+  return refs;
+}
+
+function getActiveReference(
+  value: string,
+  caret: number,
+): { start: number; end: number; query: string } | null {
+  const triggerStart = value.lastIndexOf(FILE_REFERENCE_TRIGGER, caret);
+  if (triggerStart === -1) return null;
+
+  const between = value.slice(triggerStart + FILE_REFERENCE_TRIGGER.length, caret);
+  if (!between && value.slice(triggerStart, caret) !== FILE_REFERENCE_TRIGGER) {
+    return null;
+  }
+  if (between.includes("}") || /\s/.test(between)) return null;
+
+  const closingIndex = value.indexOf("}", triggerStart + FILE_REFERENCE_TRIGGER.length);
+  if (closingIndex !== -1 && closingIndex < caret) return null;
+
+  return {
+    start: triggerStart,
+    end: closingIndex === -1 ? caret : closingIndex + 1,
+    query: between,
+  };
+}
+
+interface FileReferenceTextareaProps {
+  value: string;
+  onChange: (value: string) => void;
+  suggestions: string[];
+  currentKey?: string;
+  placeholder?: string;
+  rows?: number;
+  className?: string;
+  style?: CSSProperties;
+  helperText?: string;
+  showReferences?: boolean;
+}
+
+export function FileReferenceTextarea({
+  value,
+  onChange,
+  suggestions,
+  currentKey,
+  placeholder,
+  rows = 4,
+  className = "w-full px-2 py-1.5 text-[12px] rounded border resize-y",
+  style,
+  helperText = "Type @{ to reference another file.",
+  showReferences = true,
+}: FileReferenceTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [activeReference, setActiveReference] = useState<{ start: number; end: number; query: string } | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const referencedFiles = useMemo(
+    () => extractReferencedFiles(value, currentKey),
+    [value, currentKey],
+  );
+
+  const filteredSuggestions = useMemo(() => {
+    if (!activeReference) return [];
+    const query = activeReference.query.trim().toLowerCase();
+    return suggestions
+      .filter((key) => key !== currentKey)
+      .filter((key) => !query || key.toLowerCase().includes(query))
+      .slice(0, 8);
+  }, [activeReference, currentKey, suggestions]);
+
+  const refreshActiveReference = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || textarea.selectionStart !== textarea.selectionEnd) {
+      setActiveReference(null);
+      return;
+    }
+    setActiveReference(getActiveReference(textarea.value, textarea.selectionStart));
+  }, []);
+
+  const applySuggestion = useCallback((suggestion: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const currentValue = textarea.value;
+    const nextActive = getActiveReference(currentValue, textarea.selectionStart);
+    if (!nextActive) return;
+
+    const nextValue = `${currentValue.slice(0, nextActive.start)}@{${suggestion}}${currentValue.slice(nextActive.end)}`;
+    const nextCaret = nextActive.start + suggestion.length + 3;
+    onChange(nextValue);
+
+    requestAnimationFrame(() => {
+      const nextTextarea = textareaRef.current;
+      if (!nextTextarea) return;
+      nextTextarea.focus();
+      nextTextarea.setSelectionRange(nextCaret, nextCaret);
+      setActiveReference(getActiveReference(nextValue, nextCaret));
+    });
+  }, [onChange]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [filteredSuggestions]);
+
+  return (
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          requestAnimationFrame(refreshActiveReference);
+        }}
+        onClick={refreshActiveReference}
+        onFocus={refreshActiveReference}
+        onKeyUp={refreshActiveReference}
+        onSelect={refreshActiveReference}
+        onBlur={() => {
+          setTimeout(() => setActiveReference(null), 0);
+        }}
+        onKeyDown={(e) => {
+          if (!activeReference || filteredSuggestions.length === 0) return;
+
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setHighlightedIndex((idx) => (idx + 1) % filteredSuggestions.length);
+            return;
+          }
+          if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setHighlightedIndex((idx) => (idx - 1 + filteredSuggestions.length) % filteredSuggestions.length);
+            return;
+          }
+          if (e.key === "Enter" || e.key === "Tab") {
+            e.preventDefault();
+            applySuggestion(filteredSuggestions[highlightedIndex] ?? filteredSuggestions[0]);
+            return;
+          }
+          if (e.key === "Escape") {
+            setActiveReference(null);
+          }
+        }}
+        placeholder={placeholder}
+        rows={rows}
+        className={className}
+        style={style}
+      />
+      {activeReference && filteredSuggestions.length > 0 && (
+        <div
+          className="absolute left-0 right-0 mt-1 rounded-md overflow-hidden z-30"
+          style={{
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border)",
+            boxShadow: "0 10px 30px rgba(0,0,0,0.18)",
+            maxHeight: "180px",
+            overflowY: "auto",
+          }}
+        >
+          {filteredSuggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                applySuggestion(suggestion);
+              }}
+              className="w-full text-left px-2 py-1.5 border-0 font-mono text-[11px] cursor-pointer"
+              style={{
+                background: index === highlightedIndex ? "var(--bg-hover)" : "transparent",
+                color: index === highlightedIndex ? "var(--accent)" : "var(--text-secondary)",
+              }}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+      {(helperText || (showReferences && referencedFiles.length > 0)) && (
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[9px] text-[var(--text-muted)]">
+          {helperText && <span>{helperText}</span>}
+          {showReferences && referencedFiles.length > 0 && (
+            <span className="font-mono">
+              refs: {referencedFiles.join(", ")}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/cogos/files/context_engine.py
+++ b/src/cogos/files/context_engine.py
@@ -14,6 +14,7 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from cogos.files.references import extract_file_references
 from cogos.files.store import FileStore
 
 if TYPE_CHECKING:
@@ -54,26 +55,35 @@ class ContextEngine:
         """Build the complete prompt for a process.
 
         Resolves all attached files (with their includes) and prepends
-        them before ``process.content``.  This is the single source of
-        truth used by both the executor and the dashboard.
+        them before ``process.content``. References written inline as
+        ``@{file-key}`` are also resolved when the process has readable
+        access to that key. This is the single source of truth used by
+        both the executor and the dashboard.
         """
         sections: list[str] = []
-        visited: set[str] = set()
+        root_keys_seen: set[str] = set()
+        prompt_reference_keys = self._resolve_prompt_reference_keys(process)
 
         # Resolve each attached file (process.files)
         for fid in process.files or []:
             file = self._store.get_by_id(fid)
-            if not file or file.key in visited:
+            if not file or file.key in root_keys_seen:
                 continue
-            visited.add(file.key)
-            sections.append(self._resolve_key(file.key, visited=set(visited)))
+            root_keys_seen.add(file.key)
+            sections.append(self._resolve_key(file.key, visited=set()))
 
         # Legacy: single code FK (only if no files list)
         if process.code and not process.files:
             file = self._store.get_by_id(process.code)
-            if file and file.key not in visited:
-                visited.add(file.key)
-                sections.append(self._resolve_key(file.key, visited=set(visited)))
+            if file and file.key not in root_keys_seen:
+                root_keys_seen.add(file.key)
+                sections.append(self._resolve_key(file.key, visited=set()))
+
+        for key in prompt_reference_keys:
+            if key in root_keys_seen:
+                continue
+            root_keys_seen.add(key)
+            sections.append(self._resolve_key(key, visited=set()))
 
         # Append process.content last
         if process.content:
@@ -87,14 +97,16 @@ class ContextEngine:
         Returns a list of dicts in include-order (deepest deps first):
         ``[{"key": str, "content": str, "is_direct": bool}, ...]``
 
-        Each file appears at most once.  ``is_direct`` is True for files
-        explicitly attached to the process (i.e. in ``process.files``).
-        The final entry (if ``process.content`` is set) has
+        Each file appears at most once. ``is_direct`` is True for files
+        explicitly attached to the process or referenced directly from
+        ``process.content`` using ``@{file-key}``. The final entry (if
+        ``process.content`` is set) has
         ``key = "<content>"`` and ``is_direct = True``.
         """
         result: list[dict] = []
         seen: set[str] = set()
         direct_keys: set[str] = set()
+        prompt_reference_keys = self._resolve_prompt_reference_keys(process)
 
         # Collect direct file keys
         for fid in process.files or []:
@@ -108,6 +120,8 @@ class ContextEngine:
             if file:
                 direct_keys.add(file.key)
 
+        direct_keys.update(prompt_reference_keys)
+
         # Resolve each direct file and its includes
         for fid in process.files or []:
             file = self._store.get_by_id(fid)
@@ -119,6 +133,10 @@ class ContextEngine:
             file = self._store.get_by_id(process.code)
             if file and file.key not in seen:
                 self._collect_tree(file.key, seen, result, direct_keys)
+
+        for key in prompt_reference_keys:
+            if key not in seen:
+                self._collect_tree(key, seen, result, direct_keys)
 
         # Append process.content last
         if process.content:
@@ -157,6 +175,37 @@ class ContextEngine:
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
+
+    def _resolve_prompt_reference_keys(self, process: Process) -> list[str]:
+        keys: list[str] = []
+        for key in extract_file_references(process.content or ""):
+            if self._can_process_read_key(process, key):
+                keys.append(key)
+            else:
+                logger.warning("Process %s cannot read prompt reference %s", process.name, key)
+        return keys
+
+    def _can_process_read_key(self, process: Process, key: str) -> bool:
+        repo = self._store.repo
+        for grant in repo.list_process_capabilities(process.id):
+            capability = repo.get_capability(grant.capability)
+            if not capability:
+                continue
+
+            cfg = grant.config or {}
+            ops = cfg.get("ops")
+            if isinstance(ops, list) and "read" not in ops:
+                continue
+
+            if capability.name == "file":
+                scoped_key = cfg.get("key")
+                if scoped_key is None or str(scoped_key) == key:
+                    return True
+            elif capability.name in {"dir", "files"}:
+                prefix = cfg.get("prefix")
+                if prefix is None or key.startswith(str(prefix)):
+                    return True
+        return False
 
     def _resolve_key(self, key: str, *, visited: set[str]) -> str:
         """Recursively resolve *key* and its includes.

--- a/src/cogos/files/store.py
+++ b/src/cogos/files/store.py
@@ -15,6 +15,10 @@ class FileStore:
     def __init__(self, repo) -> None:  # noqa: ANN001
         self._repo = repo
 
+    @property
+    def repo(self):  # noqa: ANN201
+        return self._repo
+
     def create(
         self,
         key: str,

--- a/tests/cogos/test_file_references.py
+++ b/tests/cogos/test_file_references.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from cogos.db.models import Capability, Process, ProcessCapability
 from cogos.db.local_repository import LocalRepository
+from cogos.files.context_engine import ContextEngine
 from cogos.files.references import extract_file_references, merge_file_references
 from cogos.files.store import FileStore
 
@@ -51,3 +53,59 @@ def test_new_version_updates_includes(tmp_path: Path) -> None:
     updated = repo.get_file_by_id(created.id)
     assert updated is not None
     assert updated.includes == ["shared/updated"]
+
+
+def test_process_prompt_references_include_readable_files(tmp_path: Path) -> None:
+    repo = LocalRepository(data_dir=str(tmp_path))
+    store = FileStore(repo)
+    store.create("secrets/reference", "classified")
+    store.create("private/blocked", "blocked")
+
+    proc = Process(name="agent", content="tell me @{secrets/reference} and @{private/blocked}")
+    repo.upsert_process(proc)
+
+    dir_cap = Capability(name="dir")
+    repo.upsert_capability(dir_cap)
+    repo.create_process_capability(
+        ProcessCapability(
+            process=proc.id,
+            capability=dir_cap.id,
+            name="read_secrets",
+            config={"prefix": "secrets/", "ops": ["read"]},
+        ),
+    )
+
+    engine = ContextEngine(store)
+    prompt = engine.generate_full_prompt(proc)
+    tree = engine.resolve_prompt_tree(proc)
+
+    assert "--- secrets/reference ---\nclassified" in prompt
+    assert "--- private/blocked ---" not in prompt
+    assert [entry["key"] for entry in tree] == ["secrets/reference", "<content>"]
+
+
+def test_process_prompt_references_ignore_non_readable_grants(tmp_path: Path) -> None:
+    repo = LocalRepository(data_dir=str(tmp_path))
+    store = FileStore(repo)
+    store.create("secrets/reference", "classified")
+
+    proc = Process(name="agent", content="tell me @{secrets/reference}")
+    repo.upsert_process(proc)
+
+    dir_cap = Capability(name="dir")
+    repo.upsert_capability(dir_cap)
+    repo.create_process_capability(
+        ProcessCapability(
+            process=proc.id,
+            capability=dir_cap.id,
+            name="write_only_secrets",
+            config={"prefix": "secrets/", "ops": ["write"]},
+        ),
+    )
+
+    engine = ContextEngine(store)
+    prompt = engine.generate_full_prompt(proc)
+    tree = engine.resolve_prompt_tree(proc)
+
+    assert "--- secrets/reference ---" not in prompt
+    assert [entry["key"] for entry in tree] == ["<content>"]


### PR DESCRIPTION
Problem

The files pane had file-reference autocomplete, but the process Prompt Source editor and inline file editors still used plain textareas. The process editor help text said @{file-key} worked even though there were no suggestions and prompt-source references were not resolved into the assembled prompt.

Summary

- extract a shared file-reference textarea and reuse it in the files pane, process Prompt Source, and inline file editors
- suggest prompt references from readable file and dir grants so the process form only offers reachable file keys
- resolve readable @{file-key} references from process content in the context engine and cover the new behavior with tests

Testing

- npm run type-check
- uv run --extra dev pytest tests/cogos/test_file_references.py
