### PR TITLE
Isolate local dev state and dashboard ports by checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ polis/shared/{key}         # Org-wide shared keys (e.g., polis/shared/jwt-signin
 
 ## Running a Cogent Locally vs on AWS
 
-`cogent local ...` (or `cogos -c local ...`) means run on this machine using LocalRepository (JSON file at `~/.cogent/local/cogos_data.json`). Any other cogent name (for example `dr.alpha`) targets that cogent's AWS infrastructure (RDS, Lambda, ECS).
+`cogent local ...` (or `cogos -c local ...`) means run on this machine using LocalRepository. By default, each checkout gets its own local JSON store at `.local/cogos/cogos_data.json` under that repo. Set `COGENT_LOCAL_DATA` to override it. Any other cogent name (for example `dr.alpha`) targets that cogent's AWS infrastructure (RDS, Lambda, ECS).
 
 ### Local: Run CogOS on this machine
 
@@ -105,14 +105,16 @@ Validation checklist with step-by-step commands: `tests/cogos/local_validation.m
 
 ## Dashboard Ports
 
-Ports are configured in the repo root `.env` file:
+Dashboard ports can be pinned in the repo root `.env` file:
 
 ```
 DASHBOARD_BE_PORT=8100    # FastAPI backend
 DASHBOARD_FE_PORT=5200    # Next.js frontend dev server
 ```
 
-In dev mode, the Next.js frontend proxies `/api/*` and `/ws/*` to the backend via `rewrites` in `next.config.ts`. You access the app at the **frontend port** (e.g., `http://localhost:5200`), and it forwards API calls to the backend port transparently.
+If `.env` does not set them, the CLI and `dashboard/ports.sh` derive a stable backend/frontend port pair from the checkout path so multiple clones can run side by side without port collisions.
+
+In dev mode, the Next.js frontend proxies `/api/*` and `/ws/*` to the backend via `rewrites` in `next.config.ts`. You access the app at the **frontend port** (for example the derived value or the one in `.env`), and it forwards API calls to the backend port transparently.
 
 In production (Docker), both are served on a single port (8100) — Next.js is statically exported and served by FastAPI.
 
@@ -130,6 +132,14 @@ cogent dr.alpha dashboard serve --db prod      # live polis DB
 ```
 
 `cogos dashboard start` runs both backend and frontend in the background, tracking PIDs for clean stop/reload. Logs go to `/tmp/cogent-backend.log` and `/tmp/cogent-frontend.log`.
+
+# Manual (two terminals):
+source dashboard/ports.sh
+USE_LOCAL_DB=1 uv run uvicorn dashboard.app:app --host 0.0.0.0 --port "$DASHBOARD_BE_PORT"
+cd dashboard/frontend && npm run dev
+```
+
+`--db local` sets `USE_LOCAL_DB=1` and defaults `COGENT_LOCAL_DATA` to this checkout's `.local/cogos` directory. `--db prod` assumes into the polis account to get live RDS credentials.
 
 ## Remote Deployment and Testing
 
@@ -187,10 +197,19 @@ Start the dashboard:
 cogent local cogos dashboard start
 ```
 
+Or manually:
+
+```bash
+source dashboard/ports.sh
+USE_LOCAL_DB=1 uv run uvicorn dashboard.app:app --host 0.0.0.0 --port "$DASHBOARD_BE_PORT" --reload
+cd dashboard/frontend && npm run dev
+```
+
 ### Quick Start
 
 ```bash
-npx agent-browser open http://localhost:5200 && npx agent-browser wait --load networkidle && npx agent-browser snapshot -i
+source dashboard/ports.sh
+npx agent-browser open "http://localhost:$DASHBOARD_FE_PORT" && npx agent-browser wait --load networkidle && npx agent-browser snapshot -i
 ```
 
 ### Dashboard Panels to Test
@@ -212,7 +231,8 @@ The dashboard uses CogOS routers. Key tabs:
 
 ```bash
 # Open dashboard and orient
-npx agent-browser open http://localhost:5200
+source dashboard/ports.sh
+npx agent-browser open "http://localhost:$DASHBOARD_FE_PORT"
 npx agent-browser wait --load networkidle
 npx agent-browser snapshot -i
 
@@ -237,7 +257,7 @@ npx agent-browser screenshot --annotate ./test-output/dashboard.png
 For a full QA pass, use the `dogfood` skill:
 
 ```
-/dogfood http://localhost:5200
+/dogfood http://localhost:<frontend-port>
 ```
 
 This will systematically explore the dashboard, document issues with screenshots and repro videos, and produce a structured report.
@@ -273,14 +293,14 @@ The backend serves REST API under `/api/cogents/{name}/`:
 
 ### Architecture
 
-- **Backend**: FastAPI + RDS Data API, port 8100
-- **Frontend**: Next.js 15 + React 19 + Tailwind v4, port 5200 by default
+- **Backend**: FastAPI + RDS Data API, checkout-derived dev port unless overridden
+- **Frontend**: Next.js 15 + React 19 + Tailwind v4, checkout-derived dev port unless overridden
 - **Real-time**: WebSocket via PostgreSQL LISTEN/NOTIFY
 - **Auth**: API key in `x-api-key` header (SHA-256 hashed, stored in Secrets Manager)
 
 ### Database Connection
 
-Both the dashboard and `cogos` CLI require RDS Data API credentials (`DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME`). Set `USE_LOCAL_DB=1` to use LocalRepository (JSON file at `~/.cogent/local/cogos_data.json`) for local dev without AWS.
+Both the dashboard and `cogos` CLI require RDS Data API credentials (`DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME`). Set `USE_LOCAL_DB=1` to use LocalRepository for local dev without AWS. The CLI defaults local state to `.local/cogos/cogos_data.json` in the current checkout unless `COGENT_LOCAL_DATA` is set.
 
 ## Development
 

--- a/dashboard/ports.sh
+++ b/dashboard/ports.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Load dashboard ports from the repo root .env file.
+# Load dashboard/local-dev defaults for this checkout.
 # Usage: source dashboard/ports.sh  (from bash or zsh)
 
 # Handle both bash and zsh
@@ -13,6 +13,11 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "$_PORTS_SCRIPT")/.." && pwd)"
 ENV_FILE="$REPO_ROOT/.env"
+_PORTS_SOURCED=0
+
+if (return 0 2>/dev/null); then
+  _PORTS_SOURCED=1
+fi
 
 if [ -f "$ENV_FILE" ]; then
   while IFS='=' read -r key val; do
@@ -26,14 +31,32 @@ if [ -f "$ENV_FILE" ]; then
   done < "$ENV_FILE"
 fi
 
-# Fallback defaults
-export DASHBOARD_BE_PORT="${DASHBOARD_BE_PORT:-8100}"
-export DASHBOARD_FE_PORT="${DASHBOARD_FE_PORT:-5200}"
+if command -v shasum >/dev/null 2>&1; then
+  _PORTS_HASH="$(printf '%s' "$REPO_ROOT" | shasum -a 256 | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  _PORTS_HASH="$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')"
+else
+  _PORTS_HASH="00000000"
+fi
 
-unset _PORTS_SCRIPT
+_PORTS_SLOT=$(( 16#$(printf '%s' "$_PORTS_HASH" | cut -c1-8) % 5000 ))
+_DEFAULT_BE_PORT=$(( 23000 + _PORTS_SLOT ))
+_DEFAULT_FE_PORT=$(( 28000 + _PORTS_SLOT ))
+
+export COGENT_LOCAL_DATA="${COGENT_LOCAL_DATA:-$REPO_ROOT/.local/cogos}"
+export DASHBOARD_BE_PORT="${DASHBOARD_BE_PORT:-$_DEFAULT_BE_PORT}"
+export DASHBOARD_FE_PORT="${DASHBOARD_FE_PORT:-$_DEFAULT_FE_PORT}"
 
 # If executed (not sourced), print for eval.
-if [ "${BASH_SOURCE[0]:-$0}" = "$0" ] 2>/dev/null; then
+if [ "$_PORTS_SOURCED" -eq 0 ]; then
+  echo "export COGENT_LOCAL_DATA=$COGENT_LOCAL_DATA"
   echo "export DASHBOARD_BE_PORT=$DASHBOARD_BE_PORT"
   echo "export DASHBOARD_FE_PORT=$DASHBOARD_FE_PORT"
 fi
+
+unset _PORTS_SCRIPT
+unset _PORTS_SOURCED
+unset _PORTS_HASH
+unset _PORTS_SLOT
+unset _DEFAULT_BE_PORT
+unset _DEFAULT_FE_PORT

--- a/docs/cogos/guide.md
+++ b/docs/cogos/guide.md
@@ -9,7 +9,7 @@ Practical guide to operating CogOS -- creating images, booting cogents, managing
 - AWS credentials configured (profile `softmax-org`)
 - Python with `uv` for dependency management
 - Environment variables for DB: `DB_RESOURCE_ARN`, `DB_SECRET_ARN`, `DB_NAME`, `AWS_REGION`
-- For local dev: set `USE_LOCAL_DB=1` to use LocalRepository (JSON file at `~/.cogent/local/cogos_data.json`)
+- For local dev: `cogent local ...` defaults to a checkout-local JSON store at `.local/cogos/cogos_data.json`; set `COGENT_LOCAL_DATA` to override it
 
 ### Boot a Cogent
 
@@ -511,12 +511,15 @@ The dashboard provides a web UI for monitoring and managing CogOS. It runs as a 
 cogent local dashboard serve --db local
 
 # Manual alternative:
-# Backend (port 8100 by default)
-USE_LOCAL_DB=1 uv run uvicorn dashboard.app:app --host 0.0.0.0 --port 8100 --reload
+# Backend
+source dashboard/ports.sh
+USE_LOCAL_DB=1 uv run uvicorn dashboard.app:app --host 0.0.0.0 --port "$DASHBOARD_BE_PORT" --reload
 
-# Frontend (port 5200 by default)
+# Frontend
 cd dashboard/frontend && npm run dev
 ```
+
+If the repo root `.env` does not pin `DASHBOARD_BE_PORT` / `DASHBOARD_FE_PORT`, `dashboard/ports.sh` and `cogent local dashboard serve` derive a stable port pair from the checkout path so multiple clones can run side by side.
 
 The dashboard reads from the same local repo as `cogent local cogos ...`, so boot local state first:
 

--- a/src/cli/__main__.py
+++ b/src/cli/__main__.py
@@ -4,6 +4,7 @@ import sys
 import click
 
 from cli.dashboard import dashboard
+from cli.local_dev import apply_local_checkout_env
 
 # Known top-level commands — used to detect cogent name argument
 _COMMANDS = {"dashboard", "cogtainer", "memory", "run", "cogos", "status", "--help", "-h"}
@@ -19,7 +20,7 @@ def _preprocess_argv() -> None:
     if args and not args[0].startswith("-") and args[0] not in _COMMANDS:
         os.environ["COGENT_ID"] = args[0]
         if args[0] == "local":
-            os.environ["USE_LOCAL_DB"] = "1"
+            apply_local_checkout_env()
         sys.argv = [sys.argv[0]] + args[1:]
 
 

--- a/src/cli/dashboard.py
+++ b/src/cli/dashboard.py
@@ -10,31 +10,20 @@ import webbrowser
 from pathlib import Path
 
 import click
+
+from cli.local_dev import apply_local_checkout_env, repo_root, resolve_dashboard_ports
 from polis.aws import DEFAULT_ORG_PROFILE, ORG_PROFILE_ENV, resolve_org_profile
 
 _COGENT_DIR = Path.home() / ".cogents"
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = repo_root()
 _FRONTEND_DIR = _REPO_ROOT / "dashboard" / "frontend"
 _PROFILE_HELP = f"AWS profile for DB lookup (default: ${ORG_PROFILE_ENV} or {DEFAULT_ORG_PROFILE})"
 _REQUIRED_DB_ENV = ("DB_RESOURCE_ARN", "DB_SECRET_ARN", "DB_NAME")
 
 
 def _checkout_ports() -> tuple[int, int]:
-    """Read BE/FE ports from repo root .env file."""
-    env_file = _REPO_ROOT / ".env"
-    be, fe = 8100, 5200
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if line.startswith("#") or "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            v = v.split("#")[0].strip()
-            if k == "DASHBOARD_BE_PORT":
-                be = int(v)
-            elif k == "DASHBOARD_FE_PORT":
-                fe = int(v)
-    return be, fe
+    """Resolve dashboard ports from env, repo .env, or checkout defaults."""
+    return resolve_dashboard_ports(repo_root=_REPO_ROOT)
 
 
 def _key_file(name: str) -> Path:
@@ -201,7 +190,7 @@ def serve(
     }
 
     if db_mode == "local":
-        env["USE_LOCAL_DB"] = "1"
+        apply_local_checkout_env(env, repo_root=_REPO_ROOT)
     else:
         env = _ensure_db_env(name, env, assume_polis=(db_mode == "prod"), profile=profile)
         missing = _missing_db_env(env)

--- a/src/cli/local_dev.py
+++ b/src/cli/local_dev.py
@@ -1,0 +1,79 @@
+"""Helpers for per-checkout local-development defaults."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Mapping, MutableMapping
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LOCAL_DATA_SUBDIR = Path(".local") / "cogos"
+_DASHBOARD_PORT_SPAN = 5000
+_DASHBOARD_BE_BASE = 23000
+_DASHBOARD_FE_BASE = 28000
+
+
+def repo_root() -> Path:
+    """Return the checkout root for the current source tree."""
+    return _REPO_ROOT
+
+
+def default_local_data_dir(*, repo_root: Path | None = None) -> Path:
+    """Return the default local CogOS data directory for this checkout."""
+    root = (repo_root or _REPO_ROOT).resolve()
+    return root / _LOCAL_DATA_SUBDIR
+
+
+def default_dashboard_ports(*, repo_root: Path | None = None) -> tuple[int, int]:
+    """Return a stable backend/frontend port pair for this checkout."""
+    root = (repo_root or _REPO_ROOT).resolve()
+    digest = hashlib.sha256(str(root).encode("utf-8")).hexdigest()
+    slot = int(digest[:8], 16) % _DASHBOARD_PORT_SPAN
+    return _DASHBOARD_BE_BASE + slot, _DASHBOARD_FE_BASE + slot
+
+
+def apply_local_checkout_env(
+    env: MutableMapping[str, str] | None = None,
+    *,
+    repo_root: Path | None = None,
+) -> MutableMapping[str, str]:
+    """Populate local-only env defaults without overwriting explicit overrides."""
+    target = env if env is not None else os.environ
+    target["USE_LOCAL_DB"] = "1"
+    target.setdefault("COGENT_LOCAL_DATA", str(default_local_data_dir(repo_root=repo_root)))
+    return target
+
+
+def resolve_dashboard_ports(
+    *,
+    env: Mapping[str, str] | None = None,
+    repo_root: Path | None = None,
+) -> tuple[int, int]:
+    """Resolve dashboard ports from env, repo .env, or checkout-derived defaults."""
+    root = (repo_root or _REPO_ROOT).resolve()
+    current_env = env if env is not None else os.environ
+    env_file_values = _read_repo_env(root / ".env")
+    default_be, default_fe = default_dashboard_ports(repo_root=root)
+
+    be_raw = current_env.get("DASHBOARD_BE_PORT") or env_file_values.get("DASHBOARD_BE_PORT")
+    fe_raw = current_env.get("DASHBOARD_FE_PORT") or env_file_values.get("DASHBOARD_FE_PORT")
+
+    return (
+        int(be_raw) if be_raw else default_be,
+        int(fe_raw) if fe_raw else default_fe,
+    )
+
+
+def _read_repo_env(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value.split("#", 1)[0].strip()
+    return values

--- a/src/cogos/cli/__main__.py
+++ b/src/cogos/cli/__main__.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 import click
 
+from cli.local_dev import apply_local_checkout_env, repo_root, resolve_dashboard_ports
 
 _bedrock_session = None
 
@@ -117,7 +118,7 @@ def cogos(ctx: click.Context, cogent: str):
     ctx.ensure_object(dict)
     ctx.obj["cogent_name"] = cogent
     if cogent == "local":
-        os.environ["USE_LOCAL_DB"] = "1"
+        apply_local_checkout_env()
     else:
         _ensure_db_env(cogent)
 
@@ -165,8 +166,8 @@ def _run_migrations(repo) -> None:
 @click.pass_context
 def boot(ctx: click.Context, name: str, clean: bool):
     """Boot CogOS from an image."""
-    from cogos.image.spec import load_image
     from cogos.image.apply import apply_image
+    from cogos.image.spec import load_image
 
     # Find image directory
     repo_root = Path(__file__).resolve().parents[3]
@@ -247,7 +248,7 @@ def image_list():
 
 def _publish_process_event(repo, process, payload: dict) -> None:
     """Publish a message to the process's implicit channel (process:<name>)."""
-    from cogos.db.models import Channel, ChannelType, ChannelMessage
+    from cogos.db.models import Channel, ChannelMessage, ChannelType
     ch_name = f"process:{process.name}"
     ch = repo.get_channel_by_name(ch_name)
     if not ch:
@@ -333,9 +334,9 @@ def process_run(name: str, local: bool):
         return
 
     if local:
+        from cogos.db.models import ProcessStatus, Run, RunStatus
         from cogos.executor.handler import get_config
         from cogos.runtime.local import run_and_complete
-        from cogos.db.models import ProcessStatus, Run, RunStatus
 
         config = get_config()
         repo.update_process_status(p.id, ProcessStatus.RUNNING)
@@ -383,8 +384,15 @@ def process_load(file_path: str):
     channel names).
     """
     from cogos.db.models import (
-        Process as ProcessModel, ProcessMode, ProcessStatus,
-        Handler as HandlerModel, ProcessCapability,
+        Handler as HandlerModel,
+    )
+    from cogos.db.models import (
+        Process as ProcessModel,
+    )
+    from cogos.db.models import (
+        ProcessCapability,
+        ProcessMode,
+        ProcessStatus,
     )
 
     fp = Path(file_path).resolve()
@@ -504,7 +512,8 @@ def handler_list(process_name: str | None, use_json: bool):
 @click.argument("channel_name")
 def handler_add(process_name: str, channel_name: str):
     """Add a handler subscribing a process to a channel."""
-    from cogos.db.models import Handler as HandlerModel, Channel, ChannelType
+    from cogos.db.models import Channel, ChannelType
+    from cogos.db.models import Handler as HandlerModel
     repo = _repo()
     p = repo.get_process_by_name(process_name)
     if not p:
@@ -722,8 +731,9 @@ def capability_load(directory: str):
     Each entry should be a dict with keys matching the Capability model
     (name, description, handler, schema, etc.).
     """
-    from cogos.db.models import Capability as CapabilityModel
     import importlib.util
+
+    from cogos.db.models import Capability as CapabilityModel
 
     repo = _repo()
     dir_path = Path(directory).resolve()
@@ -771,7 +781,8 @@ def channel():
 @click.option("--payload", default="{}")
 def channel_send(channel_name: str, payload: str):
     """Send a message to a channel."""
-    from cogos.db.models import Channel as ChannelModel, ChannelType, ChannelMessage
+    from cogos.db.models import Channel as ChannelModel
+    from cogos.db.models import ChannelMessage, ChannelType
     repo = _repo()
     ch = repo.get_channel_by_name(channel_name)
     if not ch:
@@ -884,8 +895,8 @@ def reload(ctx: click.Context, image: str, yes: bool):
     if not yes:
         click.confirm(f"This will DELETE ALL data and reload from '{image}'. Continue?", abort=True)
 
-    from cogos.image.spec import load_image
     from cogos.image.apply import apply_image
+    from cogos.image.spec import load_image
 
     repo_root = Path(__file__).resolve().parents[3]
     image_dir = repo_root / "images" / image
@@ -954,27 +965,14 @@ def run_local(ctx: click.Context, poll_interval: float, once: bool):
 # DASHBOARD commands
 # ═══════════════════════════════════════════════════════════
 
-_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REPO_ROOT = repo_root()
 _FRONTEND_DIR = _REPO_ROOT / "dashboard" / "frontend"
 _PID_DIR = Path("/tmp/cogent-dashboard")
 
 
 def _read_ports() -> tuple[int, int]:
-    """Read BE/FE ports from .env."""
-    env_file = _REPO_ROOT / ".env"
-    be, fe = 8100, 5200
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if line.startswith("#") or "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            v = v.split("#")[0].strip()
-            if k == "DASHBOARD_BE_PORT":
-                be = int(v)
-            elif k == "DASHBOARD_FE_PORT":
-                fe = int(v)
-    return be, fe
+    """Resolve BE/FE ports from env, repo .env, or checkout defaults."""
+    return resolve_dashboard_ports(repo_root=_REPO_ROOT)
 
 
 def _pid_alive(pid: int) -> bool:
@@ -1051,7 +1049,12 @@ def dashboard_start():
     _kill_port(be_port)
     _kill_port(fe_port)
 
-    env = {**os.environ, "USE_LOCAL_DB": "1", "DASHBOARD_BE_PORT": str(be_port)}
+    env = {
+        **os.environ,
+        "DASHBOARD_BE_PORT": str(be_port),
+        "DASHBOARD_FE_PORT": str(fe_port),
+    }
+    apply_local_checkout_env(env, repo_root=_REPO_ROOT)
 
     # Start backend
     be_proc = _sp.Popen(

--- a/src/dashboard/db.py
+++ b/src/dashboard/db.py
@@ -1,8 +1,9 @@
 """Singleton Repository for dashboard handlers.
 
 Requires DB_RESOURCE_ARN (or DB_CLUSTER_ARN), DB_SECRET_ARN, and DB_NAME env vars
-for RDS Data API. Set USE_LOCAL_DB=1 to use LocalRepository (JSON file
-persistence) for local dev.
+for RDS Data API. Set USE_LOCAL_DB=1 to use LocalRepository for local dev; the
+CLI defaults that store to the current checkout's `.local/cogos/` directory
+unless COGENT_LOCAL_DATA overrides it.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_local_dev.py
+++ b/tests/cli/test_local_dev.py
@@ -1,0 +1,44 @@
+from cli.local_dev import (
+    apply_local_checkout_env,
+    default_dashboard_ports,
+    default_local_data_dir,
+    resolve_dashboard_ports,
+)
+
+
+def test_default_local_data_dir_is_checkout_local(tmp_path):
+    assert default_local_data_dir(repo_root=tmp_path) == tmp_path / ".local" / "cogos"
+
+
+def test_default_dashboard_ports_are_stable_for_checkout(tmp_path):
+    first = default_dashboard_ports(repo_root=tmp_path)
+    second = default_dashboard_ports(repo_root=tmp_path)
+
+    assert first == second
+    assert first[0] != first[1]
+
+
+def test_resolve_dashboard_ports_prefers_repo_env(tmp_path):
+    (tmp_path / ".env").write_text("DASHBOARD_BE_PORT=8111\nDASHBOARD_FE_PORT=5211\n")
+
+    assert resolve_dashboard_ports(env={}, repo_root=tmp_path) == (8111, 5211)
+
+
+def test_resolve_dashboard_ports_prefers_process_env_over_repo_env(tmp_path):
+    (tmp_path / ".env").write_text("DASHBOARD_BE_PORT=8111\nDASHBOARD_FE_PORT=5211\n")
+
+    ports = resolve_dashboard_ports(
+        env={"DASHBOARD_BE_PORT": "8123", "DASHBOARD_FE_PORT": "5223"},
+        repo_root=tmp_path,
+    )
+
+    assert ports == (8123, 5223)
+
+
+def test_apply_local_checkout_env_sets_defaults_without_overwriting_data_dir(tmp_path):
+    env = {"COGENT_LOCAL_DATA": "/tmp/custom-local-data"}
+
+    apply_local_checkout_env(env, repo_root=tmp_path)
+
+    assert env["USE_LOCAL_DB"] == "1"
+    assert env["COGENT_LOCAL_DATA"] == "/tmp/custom-local-data"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from cli.__main__ import _preprocess_argv
+
+
+def test_preprocess_argv_sets_local_checkout_defaults(monkeypatch, tmp_path):
+    monkeypatch.setattr("cli.local_dev._REPO_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["cogent", "local", "status"])
+    monkeypatch.delenv("COGENT_ID", raising=False)
+    monkeypatch.delenv("USE_LOCAL_DB", raising=False)
+    monkeypatch.delenv("COGENT_LOCAL_DATA", raising=False)
+
+    try:
+        _preprocess_argv()
+
+        assert sys.argv == ["cogent", "status"]
+        assert os.environ["COGENT_ID"] == "local"
+        assert os.environ["USE_LOCAL_DB"] == "1"
+        assert os.environ["COGENT_LOCAL_DATA"] == str(tmp_path / ".local" / "cogos")
+    finally:
+        os.environ.pop("COGENT_ID", None)
+        os.environ.pop("USE_LOCAL_DB", None)
+        os.environ.pop("COGENT_LOCAL_DATA", None)

--- a/tests/dashboard/test_cli.py
+++ b/tests/dashboard/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 from cli.dashboard import dashboard
+from cli.local_dev import default_local_data_dir
 
 
 def test_login_creates_key(tmp_path, monkeypatch):
@@ -91,6 +92,8 @@ def test_serve_db_local_sets_use_local_db(tmp_path, monkeypatch):
         procs.append(proc)
         return proc
 
+    monkeypatch.delenv("COGENT_LOCAL_DATA", raising=False)
+    monkeypatch.setattr("cli.dashboard._REPO_ROOT", tmp_path)
     monkeypatch.setattr("cli.dashboard._FRONTEND_DIR", tmp_path / "missing")
     monkeypatch.setattr("cli.dashboard.subprocess.Popen", fake_popen)
 
@@ -104,6 +107,7 @@ def test_serve_db_local_sets_use_local_db(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert len(procs) == 1
     assert procs[0].env["USE_LOCAL_DB"] == "1"
+    assert procs[0].env["COGENT_LOCAL_DATA"] == str(default_local_data_dir(repo_root=tmp_path))
 
 
 def test_serve_db_prod_passes_profile(tmp_path, monkeypatch):


### PR DESCRIPTION
Problem

- `main` already added the local executor, explicit dashboard DB modes, background dashboard start/stop/reload, and better local-dev docs.
- The remaining gap was default isolation: `cogent local ...` still fell back to the shared home-directory JSON repo unless `COGENT_LOCAL_DATA` was set, and dashboard startup paths still relied on fixed or manually-pinned ports instead of checkout-scoped defaults.
- That meant multiple local checkouts still had no zero-config way to run fully independently, even though the local runtime itself had improved.

Summary

- Add a shared local-dev helper that derives a stable `.local/cogos` data dir and backend/frontend port pair from the checkout path while still respecting explicit env vars and repo `.env` overrides.
- Apply those defaults in `cogent local ...`, `cogos -c local ...`, `cogent ... dashboard serve --db local`, and the newer `cogent local cogos dashboard start` background workflow so all local entrypoints use the same checkout-scoped behavior.
- Update `dashboard/ports.sh` and the local-dev docs so foreground, background, manual, and agent-browser workflows all describe the new per-checkout default pattern.

Testing

- `uv run pytest tests/cli/test_local_dev.py tests/cli/test_main.py tests/dashboard/test_cli.py`
- `uv run ruff check src/cli/__main__.py src/cli/dashboard.py src/cli/local_dev.py src/cogos/cli/__main__.py src/dashboard/db.py tests/cli tests/dashboard/test_cli.py`
- `zsh -lc 'source dashboard/ports.sh && printf "%s\n%s\n%s\n" "$COGENT_LOCAL_DATA" "$DASHBOARD_BE_PORT" "$DASHBOARD_FE_PORT"'
