### PR TITLE
refactor(cogos): require inline file references

### DIFF
--- a/dashboard/frontend/src/components/files/FilesPanel.tsx
+++ b/dashboard/frontend/src/components/files/FilesPanel.tsx
@@ -167,7 +167,7 @@ function VersionPanel({ file, fileSuggestions, cogentName, canMutate, onRefresh,
         </span>
         {file.includes.length > 0 && (
           <span className="text-[10px] text-[var(--text-muted)]">
-            includes: {file.includes.join(", ")}
+            refs: {file.includes.join(", ")}
           </span>
         )}
         {canMutate && (

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -199,7 +199,7 @@ export async function getFileDetail(
 
 export async function createFile(
   name: string,
-  body: { key: string; content: string; source?: string; read_only?: boolean; includes?: string[] },
+  body: { key: string; content: string; source?: string; read_only?: boolean },
 ): Promise<CogosFile> {
   const resp = await fetch(`/api/cogents/${name}/files`, {
     method: "POST",

--- a/docs/cogos/design.md
+++ b/docs/cogos/design.md
@@ -164,7 +164,7 @@ FileVersion
   created_at      datetime
 ```
 
-Files support an include system. A file can declare `includes: ["whoami/index", "cogos/includes/code_mode"]` and the context engine resolves these recursively, depth-first, concatenating content with section headers. Circular includes are detected and reported.
+Files support prompt references via inline `@{file-key}` syntax. When a file is resolved into prompt context, the context engine recursively expands those references, depth-first, concatenating content with section headers. Circular references are detected and reported.
 
 ### Capability
 

--- a/docs/cogos/guide.md
+++ b/docs/cogos/guide.md
@@ -81,7 +81,7 @@ for cap in BUILTIN_CAPABILITIES:
 add_process(
     "scheduler",
     mode="daemon",
-    content="@{cogos/scheduler}",     # inline file include
+    content="@{cogos/scheduler}",     # inline file reference
     runner="lambda",
     priority=100.0,
     capabilities=["scheduler"],
@@ -127,16 +127,23 @@ files/cogos/docs/layout.md            -> key: "cogos/docs/layout"
 
 Files under `cogos/includes/` are automatically prepended to every process's system prompt by the executor.
 
-### File Includes
+### File References
 
-Files can reference other files using the `includes` field (set during file creation). The context engine resolves includes recursively, depth-first:
+Files can reference other files inline with `@{...}`. The context engine resolves those references recursively, depth-first:
 
 ```python
-# In a process definition, use @{...} to include a file
+# In a process definition, use @{...} to reference a file
 add_process("my-agent", content="@{agents/my-agent}", ...)
 ```
 
-The file at `agents/my-agent` might have includes `["whoami/index", "cogos/includes/code_mode"]`, and those are prepended to its content when building the prompt.
+The file at `agents/my-agent` might contain:
+
+```md
+@{whoami/index}
+@{cogos/includes/code_mode}
+```
+
+Those references are expanded directly where they appear when building the prompt.
 
 ### Boot vs Snapshot
 

--- a/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/discover.md
+++ b/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/discover.md
@@ -1,5 +1,13 @@
 # Discover — Batch Candidate Discovery
 
+## Reference Material
+@{apps/recruiter/criteria.md}
+@{apps/recruiter/rubric.json}
+@{apps/recruiter/sourcer/github.md}
+@{apps/recruiter/sourcer/twitter.md}
+@{apps/recruiter/sourcer/web.md}
+@{apps/recruiter/sourcer/substack.md}
+
 You are a discovery agent for the Softmax recruiter. Your job is to find people building coding agents and orchestration frameworks.
 
 ## Process

--- a/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/evolve.md
+++ b/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/evolve.md
@@ -1,5 +1,11 @@
 # Evolve — Self-Improvement Engine
 
+## Reference Material
+@{apps/recruiter/diagnosis.md}
+@{apps/recruiter/criteria.md}
+@{apps/recruiter/rubric.json}
+@{apps/recruiter/strategy.md}
+
 You analyze feedback and propose improvements to the recruiter system.
 
 ## Process

--- a/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/present.md
+++ b/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/present.md
@@ -1,5 +1,9 @@
 # Present — Candidate Presentation Daemon
 
+## Reference Material
+@{apps/recruiter/criteria.md}
+@{apps/recruiter/strategy.md}
+
 You present screened candidates to the team via Discord and capture feedback.
 
 ## Behavior

--- a/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/recruiter.md
+++ b/images/cogent-v1/apps/recruiter/files/apps/recruiter/prompts/recruiter.md
@@ -1,5 +1,9 @@
 # Recruiter — Root Orchestrator
 
+## Reference Material
+@{apps/recruiter/criteria.md}
+@{apps/recruiter/strategy.md}
+
 You are the recruiter daemon for Softmax. You find people building coding agents and orchestration frameworks.
 
 ## Your Job

--- a/images/cogent-v1/apps/recruiter/init/processes.py
+++ b/images/cogent-v1/apps/recruiter/init/processes.py
@@ -6,36 +6,6 @@
 # recruiter/profile (one-shot, spawned) — deep-dive HTML reports
 # recruiter/evolve (one-shot, spawned) — self-improvement
 
-# -- Context engine wiring (includes) --
-# These declare which files are injected into each prompt template.
-# File content comes from the files/ directory; add_file just sets up includes.
-
-add_file("apps/recruiter/prompts/recruiter.md", content="", includes=[
-    "apps/recruiter/criteria.md",
-    "apps/recruiter/strategy.md",
-])
-
-add_file("apps/recruiter/prompts/discover.md", content="", includes=[
-    "apps/recruiter/criteria.md",
-    "apps/recruiter/rubric.json",
-    "apps/recruiter/sourcer/github.md",
-    "apps/recruiter/sourcer/twitter.md",
-    "apps/recruiter/sourcer/web.md",
-    "apps/recruiter/sourcer/substack.md",
-])
-
-add_file("apps/recruiter/prompts/present.md", content="", includes=[
-    "apps/recruiter/criteria.md",
-    "apps/recruiter/strategy.md",
-])
-
-add_file("apps/recruiter/prompts/evolve.md", content="", includes=[
-    "apps/recruiter/diagnosis.md",
-    "apps/recruiter/criteria.md",
-    "apps/recruiter/rubric.json",
-    "apps/recruiter/strategy.md",
-])
-
 # -- Channels --
 
 add_channel("recruiter:feedback", channel_type="named")

--- a/images/cogent-v1/files/cogos/docs/fs.md
+++ b/images/cogent-v1/files/cogos/docs/fs.md
@@ -41,16 +41,17 @@ old = file_version.get("config/system", version=1)
 
 `dir` is the most common — it gives full file access under a prefix. `file` and `file_version` are for fine-grained single-key grants.
 
-## Includes
+## Prompt references
 
-Files can declare `includes` — references to other file keys. The context engine resolves includes recursively, depth-first, and concatenates them into the prompt.
+Files can reference other files inline with `@{file-key}`. The context engine resolves those references recursively, depth-first, and concatenates them into the prompt.
 
+```md
+# agents/my-agent
+@{whoami/index}
+@{cogos/includes/code_mode}
 ```
-File: agents/my-agent
-  includes: ["whoami/index", "cogos/includes/code_mode"]
-```
 
-When this file is used as a process prompt, the context engine prepends the included files automatically.
+When this file is used as a process prompt, the referenced files are expanded directly where they appear.
 
 ## Auto-injected includes
 

--- a/src/cogos/capabilities/files.py
+++ b/src/cogos/capabilities/files.py
@@ -116,14 +116,13 @@ class FilesCapability(Capability):
         content: str,
         source: str = "agent",
         read_only: bool = False,
-        includes: list[str] | None = None,
     ) -> FileWriteResult | FileError:
         if not key:
             return FileError(error="key is required")
         self._check("write", key=key)
 
         store = FileStore(self.repo)
-        result = store.upsert(key, content, source=source, read_only=read_only, includes=includes)
+        result = store.upsert(key, content, source=source, read_only=read_only)
 
         if result is None:
             return FileWriteResult(id="", key=key, version=0, created=False, changed=False)

--- a/src/cogos/files/context_engine.py
+++ b/src/cogos/files/context_engine.py
@@ -1,12 +1,11 @@
-"""Context engine -- resolves file includes to build full prompt context.
+"""Context engine -- resolves file references to build full prompt context.
 
-Files in CogOS can declare an ``includes`` list of other file keys. The
-context engine recursively resolves those includes, expands inline
-``@{file-key}`` references, concatenates their content with section
-headers, and returns a single string suitable for injection into an LLM
-prompt.
+Files in CogOS reference other files with inline ``@{file-key}`` syntax.
+The context engine parses those references from file content, resolves
+them recursively, concatenates their content with section headers, and
+returns a single string suitable for injection into an LLM prompt.
 
-Circular includes are detected and reported as errors in the output.
+Circular references are detected and reported as errors in the output.
 """
 
 from __future__ import annotations
@@ -27,7 +26,7 @@ PROMPT_REF_RE = re.compile(r"@\{([^{}\n]+)\}")
 
 
 class ContextEngine:
-    """Resolves file includes into a single concatenated context string."""
+    """Resolves file references into a single concatenated context string."""
 
     def __init__(self, file_store: FileStore) -> None:
         self._store = file_store
@@ -60,7 +59,7 @@ class ContextEngine:
         The process prompt now comes entirely from ``process.content``.
         Any inline ``@{file-key}`` references the process can read are
         expanded recursively, and referenced files still honor their own
-        ``includes`` lists.
+        inline references.
         """
         return self._expand_process_text(process, process.content, visited=set())
 
@@ -111,9 +110,6 @@ class ContextEngine:
             result.append({"key": key, "content": f"[not found: {key}]", "is_direct": key in direct_keys})
             return
 
-        for include_key in file.includes:
-            self._collect_tree(include_key, seen, result, direct_keys)
-
         content = self._store.get_content(key) or ""
         for ref_key in self._extract_refs(content):
             self._collect_tree(ref_key, seen, result, direct_keys)
@@ -155,7 +151,7 @@ class ContextEngine:
         return False
 
     def _resolve_key(self, key: str, *, visited: set[str]) -> str:
-        """Recursively resolve *key* and its includes.
+        """Recursively resolve *key* and its referenced files.
 
         *visited* tracks keys already seen on the current resolution path
         to detect circular references.
@@ -175,20 +171,8 @@ class ContextEngine:
 
         content = self._store.get_content(key) or ""
 
-        sections: list[str] = []
-        for include_key in file.includes:
-            section = self._resolve_key(include_key, visited=set(visited))
-            sections.append(section)
-
-        parts: list[str] = []
-
-        if sections:
-            parts.extend(sections)
-
         header = f"--- {key} ---"
-        parts.append(f"{header}\n{self._expand_text(content, visited=set(visited))}")
-
-        return "\n\n".join(parts)
+        return f"{header}\n{self._expand_text(content, visited=set(visited))}"
 
     def _expand_text(self, text: str, *, visited: set[str]) -> str:
         if not text:

--- a/src/cogos/files/references.py
+++ b/src/cogos/files/references.py
@@ -18,21 +18,3 @@ def extract_file_references(content: str, *, exclude_key: str | None = None) -> 
         seen.add(key)
         refs.append(key)
     return refs
-
-
-def merge_file_references(
-    content: str,
-    includes: list[str] | None = None,
-    *,
-    exclude_key: str | None = None,
-) -> list[str]:
-    """Merge explicit includes with content references, preserving order."""
-    merged: list[str] = []
-    seen: set[str] = set()
-    for key in [*(includes or []), *extract_file_references(content, exclude_key=exclude_key)]:
-        cleaned = key.strip()
-        if not cleaned or cleaned == exclude_key or cleaned in seen:
-            continue
-        seen.add(cleaned)
-        merged.append(cleaned)
-    return merged

--- a/src/cogos/files/store.py
+++ b/src/cogos/files/store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from cogos.db.models import File, FileVersion
+from cogos.files.references import extract_file_references
 
 logger = logging.getLogger(__name__)
 
@@ -26,10 +27,9 @@ class FileStore:
         *,
         source: str = "cogent",
         read_only: bool = False,
-        includes: list[str] | None = None,
     ) -> File:
         """Create a new file with version 1."""
-        f = File(key=key, includes=includes or [])
+        f = File(key=key, includes=extract_file_references(content, exclude_key=key))
         self._repo.insert_file(f)
         fv = FileVersion(
             file_id=f.id,
@@ -49,14 +49,16 @@ class FileStore:
         *,
         source: str = "cogent",
         read_only: bool = False,
-        includes: list[str] | None = None,
     ) -> FileVersion | None:
         """Add a new version if content changed. Returns None if unchanged or not found."""
         f = self._repo.get_file_by_key(key)
         if f is None:
             return None
         active = self._repo.get_active_file_version(f.id)
+        derived_includes = extract_file_references(content, exclude_key=key)
         if active and active.content == content:
+            if f.includes != derived_includes:
+                self._repo.update_file_includes(f.id, derived_includes)
             return None
         next_ver = self._repo.get_max_file_version(f.id) + 1
         # Deactivate current active
@@ -71,8 +73,7 @@ class FileStore:
             is_active=True,
         )
         self._repo.insert_file_version(fv)
-        if includes is not None:
-            self._repo.update_file_includes(f.id, includes)
+        self._repo.update_file_includes(f.id, derived_includes)
         return fv
 
     def upsert(
@@ -82,13 +83,12 @@ class FileStore:
         *,
         source: str = "cogent",
         read_only: bool = False,
-        includes: list[str] | None = None,
     ) -> File | FileVersion | None:
         """Create or update a file. Returns File on create, FileVersion on update, None if unchanged."""
         f = self._repo.get_file_by_key(key)
         if f is None:
-            return self.create(key, content, source=source, read_only=read_only, includes=includes)
-        return self.new_version(key, content, source=source, read_only=read_only, includes=includes)
+            return self.create(key, content, source=source, read_only=read_only)
+        return self.new_version(key, content, source=source, read_only=read_only)
 
     def update_includes(self, key: str, includes: list[str]) -> bool:
         f = self._repo.get_file_by_key(key)

--- a/src/cogos/image/apply.py
+++ b/src/cogos/image/apply.py
@@ -79,8 +79,7 @@ def apply_image(spec: ImageSpec, repo, *, clean: bool = False) -> dict[str, int]
     # 4. Files
     fs = FileStore(repo)
     for key, content in spec.files.items():
-        includes = spec.file_includes.get(key)
-        fs.upsert(key, content, source="image", includes=includes)
+        fs.upsert(key, content, source="image")
         counts["files"] += 1
 
     # 5. Schemas

--- a/src/cogos/image/spec.py
+++ b/src/cogos/image/spec.py
@@ -13,7 +13,6 @@ class ImageSpec:
     processes: list[dict] = field(default_factory=list)
     cron_rules: list[dict] = field(default_factory=list)
     files: dict[str, str] = field(default_factory=dict)
-    file_includes: dict[str, list[str]] = field(default_factory=dict)
     schemas: list[dict] = field(default_factory=list)
     channels: list[dict] = field(default_factory=list)
 
@@ -70,10 +69,8 @@ def load_image(image_dir: Path) -> ImageSpec:
             "auto_close": auto_close,
         })
 
-    def add_file(key, *, content="", includes=None):
+    def add_file(key, *, content=""):
         spec.files[key] = content
-        if includes:
-            spec.file_includes[key] = includes
 
     builtins = {
         "__builtins__": __builtins__,

--- a/src/dashboard/routers/files.py
+++ b/src/dashboard/routers/files.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from cogos.db.models import File, FileVersion
-from cogos.files.references import extract_file_references, merge_file_references
+from cogos.files.references import extract_file_references
 from cogos.files.store import FileStore
 from dashboard.db import get_repo
 
@@ -52,7 +52,6 @@ class FileCreate(BaseModel):
     content: str
     source: str = "cogent"
     read_only: bool = False
-    includes: list[str] | None = None
 
 
 class FileUpdate(BaseModel):
@@ -77,9 +76,8 @@ def _sync_file_includes(
     file: File,
     *,
     content: str,
-    explicit_includes: list[str] | None = None,
 ) -> list[str]:
-    includes = merge_file_references(content, explicit_includes, exclude_key=file.key)
+    includes = extract_file_references(content, exclude_key=file.key)
     store.update_includes(file.key, includes)
     return includes
 
@@ -137,13 +135,11 @@ def get_file(name: str, key: str) -> FileDetail:
 @router.post("/files", response_model=FileOut)
 def create_file(name: str, body: FileCreate) -> FileOut:
     store = _store()
-    includes = merge_file_references(body.content, body.includes, exclude_key=body.key)
     f = store.create(
         key=body.key,
         content=body.content,
         source=body.source,
         read_only=body.read_only,
-        includes=includes,
     )
     return _file_out(f)
 
@@ -154,8 +150,7 @@ def update_file(name: str, key: str, body: FileUpdate) -> FileVersionOut:
     file = store.get(key)
     if not file:
         raise HTTPException(status_code=404, detail="File not found or content unchanged")
-    includes = extract_file_references(body.content, exclude_key=file.key)
-    fv = store.new_version(key, body.content, source=body.source, read_only=body.read_only, includes=includes)
+    fv = store.new_version(key, body.content, source=body.source, read_only=body.read_only)
     if fv is None:
         raise HTTPException(status_code=404, detail="File not found or content unchanged")
     return _version_out(fv)

--- a/tests/cogos/test_context_engine.py
+++ b/tests/cogos/test_context_engine.py
@@ -18,14 +18,14 @@ def _grant_read_all(repo: LocalRepository, process: Process) -> None:
     )
 
 
-def test_generate_full_prompt_expands_inline_refs_and_file_includes(tmp_path):
+def test_generate_full_prompt_expands_inline_refs_recursively(tmp_path):
     repo = LocalRepository(str(tmp_path))
     store = FileStore(repo)
 
     store.upsert("docs/shared.md", "Shared context", source="test")
     store.upsert("docs/nested.md", "Nested details", source="test")
     store.upsert("docs/inline.md", "Inline ref -> @{docs/nested.md}", source="test")
-    store.upsert("prompts/root.md", "Root prompt", source="test", includes=["docs/shared.md"])
+    store.upsert("prompts/root.md", "Root prompt\n@{docs/shared.md}", source="test")
 
     process = Process(
         name="worker",
@@ -50,7 +50,7 @@ def test_resolve_prompt_tree_marks_direct_refs_from_process_content(tmp_path):
     store.upsert("docs/shared.md", "Shared context", source="test")
     store.upsert("docs/nested.md", "Nested details", source="test")
     store.upsert("docs/inline.md", "Inline ref -> @{docs/nested.md}", source="test")
-    store.upsert("prompts/root.md", "Root prompt", source="test", includes=["docs/shared.md"])
+    store.upsert("prompts/root.md", "Root prompt\n@{docs/shared.md}", source="test")
 
     process = Process(
         name="worker",

--- a/tests/cogos/test_executor_handler.py
+++ b/tests/cogos/test_executor_handler.py
@@ -239,7 +239,7 @@ def test_execute_process_expands_prompt_refs_into_system_prompt(monkeypatch, tmp
     repo = _repo(tmp_path)
     store = FileStore(repo)
     store.upsert("docs/shared.md", "Shared context", source="test")
-    store.upsert("prompt.md", "Prompt body", source="test", includes=["docs/shared.md"])
+    store.upsert("prompt.md", "Prompt body\n@{docs/shared.md}", source="test")
 
     process = Process(
         name="worker",
@@ -291,8 +291,8 @@ def test_execute_process_expands_prompt_refs_into_system_prompt(monkeypatch, tmp
     assert first_call["messages"][0]["content"][0]["text"] == "Execute your task."
     assert first_call["system"][0]["text"] == (
         "Intro\n"
-        "--- docs/shared.md ---\n"
-        "Shared context\n\n"
         "--- prompt.md ---\n"
-        "Prompt body"
+        "Prompt body\n"
+        "--- docs/shared.md ---\n"
+        "Shared context"
     )

--- a/tests/cogos/test_file_references.py
+++ b/tests/cogos/test_file_references.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from cogos.db.models import Capability, Process, ProcessCapability
 from cogos.db.local_repository import LocalRepository
 from cogos.files.context_engine import ContextEngine
-from cogos.files.references import extract_file_references, merge_file_references
+from cogos.files.references import extract_file_references
 from cogos.files.store import FileStore
 
 
@@ -24,14 +24,10 @@ def test_extract_file_references_preserves_order_and_uniqueness() -> None:
     ]
 
 
-def test_merge_file_references_filters_self_reference() -> None:
+def test_extract_file_references_filters_self_reference() -> None:
     content = "keep @{shared/base} ignore @{self/file}"
 
-    assert merge_file_references(
-        content,
-        ["manual/include", "shared/base"],
-        exclude_key="self/file",
-    ) == ["manual/include", "shared/base"]
+    assert extract_file_references(content, exclude_key="self/file") == ["shared/base"]
 
 
 def test_new_version_updates_includes(tmp_path: Path) -> None:
@@ -40,19 +36,32 @@ def test_new_version_updates_includes(tmp_path: Path) -> None:
     created = store.create(
         "prompts/root",
         "hello @{shared/base}",
-        includes=["shared/base"],
     )
 
     result = store.new_version(
         "prompts/root",
         "hello @{shared/updated}",
-        includes=["shared/updated"],
     )
 
     assert result is not None
     updated = repo.get_file_by_id(created.id)
     assert updated is not None
     assert updated.includes == ["shared/updated"]
+
+
+def test_unchanged_write_resyncs_derived_includes(tmp_path: Path) -> None:
+    repo = LocalRepository(data_dir=str(tmp_path))
+    store = FileStore(repo)
+    created = store.create("prompts/root", "hello @{shared/base}")
+
+    assert repo.update_file_includes(created.id, ["stale/include"]) is True
+
+    result = store.new_version("prompts/root", "hello @{shared/base}")
+
+    assert result is None
+    updated = repo.get_file_by_id(created.id)
+    assert updated is not None
+    assert updated.includes == ["shared/base"]
 
 
 def test_process_prompt_references_include_readable_files(tmp_path: Path) -> None:

--- a/tests/cogos/test_image_apply.py
+++ b/tests/cogos/test_image_apply.py
@@ -45,6 +45,20 @@ def test_apply_creates_files(tmp_path):
     assert fv.content == "You are the scheduler."
 
 
+def test_apply_derives_file_includes_from_inline_refs(tmp_path):
+    repo = LocalRepository(str(tmp_path))
+    spec = ImageSpec(files={
+        "prompts/root.md": "Root prompt\n@{docs/shared.md}",
+        "docs/shared.md": "Shared context",
+    })
+
+    apply_image(spec, repo)
+
+    f = repo.get_file_by_key("prompts/root.md")
+    assert f is not None
+    assert f.includes == ["docs/shared.md"]
+
+
 def test_apply_creates_processes_with_bindings(tmp_path):
     repo = LocalRepository(str(tmp_path))
     spec = _make_spec()

--- a/tests/cogos/test_recruiter_image.py
+++ b/tests/cogos/test_recruiter_image.py
@@ -24,7 +24,6 @@ def _write_app_image(tmp: Path) -> Path:
     app_init = tmp / "apps" / "myapp" / "init"
     app_init.mkdir(parents=True)
     (app_init / "processes.py").write_text(
-        'add_file("myapp/prompt.md", content="", includes=["myapp/config.md"])\n'
         'add_channel("myapp:events", channel_type="named")\n'
         'add_process("myapp/worker", mode="daemon", content="@{myapp/prompt.md}", '
         'capabilities=["dir"], handlers=["myapp:events"])\n'
@@ -33,7 +32,7 @@ def _write_app_image(tmp: Path) -> Path:
     # App files
     app_files = tmp / "apps" / "myapp" / "files" / "myapp"
     app_files.mkdir(parents=True)
-    (app_files / "prompt.md").write_text("You are a worker.")
+    (app_files / "prompt.md").write_text("You are a worker.\n@{myapp/config.md}")
     (app_files / "config.md").write_text("Config here.")
 
     return tmp
@@ -57,7 +56,7 @@ def test_apps_load_files():
         spec = load_image(Path(td))
 
     assert "myapp/prompt.md" in spec.files
-    assert spec.files["myapp/prompt.md"] == "You are a worker."
+    assert spec.files["myapp/prompt.md"] == "You are a worker.\n@{myapp/config.md}"
     assert "myapp/config.md" in spec.files
 
 
@@ -71,26 +70,13 @@ def test_apps_load_channels():
     assert "myapp:events" in names
 
 
-def test_add_file_includes():
-    """add_file should set up file_includes metadata."""
+def test_app_prompt_refs_are_explicit_in_file_content():
+    """App prompt dependencies should be declared inline in file content."""
     with tempfile.TemporaryDirectory() as td:
         _write_app_image(Path(td))
         spec = load_image(Path(td))
 
-    assert "myapp/prompt.md" in spec.file_includes
-    assert spec.file_includes["myapp/prompt.md"] == ["myapp/config.md"]
-
-
-def test_app_files_overwrite_add_file_content():
-    """Files from files/ dir should overwrite empty add_file content."""
-    with tempfile.TemporaryDirectory() as td:
-        _write_app_image(Path(td))
-        spec = load_image(Path(td))
-
-    # add_file set content="" but files/ dir loaded "You are a worker."
-    assert spec.files["myapp/prompt.md"] == "You are a worker."
-    # includes should still be set
-    assert spec.file_includes["myapp/prompt.md"] == ["myapp/config.md"]
+    assert "@{myapp/config.md}" in spec.files["myapp/prompt.md"]
 
 
 def test_apps_dont_affect_top_level():
@@ -141,15 +127,15 @@ def test_cogent_v1_recruiter_files():
     assert len(prompt_files) == 5
 
 
-def test_cogent_v1_recruiter_includes():
-    """Recruiter prompt files should have correct includes."""
+def test_cogent_v1_recruiter_prompt_refs_are_explicit():
+    """Recruiter prompt dependencies should be declared inline in prompt files."""
     spec = load_image(Path("images/cogent-v1"))
 
-    assert spec.file_includes["apps/recruiter/prompts/recruiter.md"] == [
-        "apps/recruiter/criteria.md", "apps/recruiter/strategy.md",
-    ]
-    assert "apps/recruiter/rubric.json" in spec.file_includes["apps/recruiter/prompts/discover.md"]
-    assert "apps/recruiter/diagnosis.md" in spec.file_includes["apps/recruiter/prompts/evolve.md"]
+    assert "@{apps/recruiter/criteria.md}" in spec.files["apps/recruiter/prompts/recruiter.md"]
+    assert "@{apps/recruiter/strategy.md}" in spec.files["apps/recruiter/prompts/recruiter.md"]
+    assert "@{apps/recruiter/rubric.json}" in spec.files["apps/recruiter/prompts/discover.md"]
+    assert "@{apps/recruiter/sourcer/github.md}" in spec.files["apps/recruiter/prompts/discover.md"]
+    assert "@{apps/recruiter/diagnosis.md}" in spec.files["apps/recruiter/prompts/evolve.md"]
 
 
 def test_cogent_v1_recruiter_channel():


### PR DESCRIPTION
## Problem

Prompt files could pull in other files through hidden `add_file(..., includes=[...])` image metadata even when the file content had no `@{...}` references. That made prompt composition ambiguous in the dashboard and in the recruiter app specifically: `discover.md` looked self-contained while resolving six unseen dependencies.

The abstraction was also unstable. Normal file edits already recomputed file dependencies from inline `@{...}` references only, so metadata-only includes could drift or disappear after an edit.

## Summary

- remove image-time hidden file includes and explicit include inputs from file write APIs; `File.includes` now exists only as derived metadata from inline `@{...}` references
- update prompt resolution to render only inline references instead of prepending a second metadata-driven include layer
- rewrite the recruiter prompts to declare their dependencies inline and update dashboard/docs wording from hidden `includes` to explicit `refs`

## Testing

- `uv run pytest tests/cogos/test_context_engine.py tests/cogos/test_file_references.py tests/cogos/test_executor_handler.py tests/cogos/test_image_apply.py tests/cogos/test_recruiter_image.py`