### PR TITLE
Preserve file suffixes in include references

### DIFF
--- a/docs/cogos/design.md
+++ b/docs/cogos/design.md
@@ -148,7 +148,7 @@ A versioned entry in a hierarchical key-value store. Stores both code (prompt te
 ```
 File
   id              UUID            PK
-  key             str             hierarchical path (e.g. "cogos/scheduler")
+  key             str             hierarchical path (e.g. "cogos/scheduler.md")
   includes        list[str]       keys of other files to include in context
   created_at      datetime
   updated_at      datetime

--- a/docs/cogos/guide.md
+++ b/docs/cogos/guide.md
@@ -81,7 +81,7 @@ for cap in BUILTIN_CAPABILITIES:
 add_process(
     "scheduler",
     mode="daemon",
-    content="@{cogos/scheduler}",     # inline file reference
+    content="@{cogos/scheduler.md}",  # inline file reference
     runner="lambda",
     priority=100.0,
     capabilities=["scheduler"],
@@ -119,11 +119,13 @@ add_cron("* * * * *", channel="system:tick:minute")
 Every file under `files/` becomes a File entry in the store. The relative path from `files/` becomes the key:
 
 ```
-files/cogos/lib/scheduler.md          -> key: "cogos/lib/scheduler"
-files/whoami/index.md                 -> key: "whoami/index"
-files/cogos/includes/code_mode.md     -> key: "cogos/includes/code_mode"
-files/cogos/docs/layout.md            -> key: "cogos/docs/layout"
+files/cogos/lib/scheduler.md          -> key: "cogos/lib/scheduler.md"
+files/whoami/index.md                 -> key: "whoami/index.md"
+files/cogos/includes/code_mode.md     -> key: "cogos/includes/code_mode.md"
+files/cogos/docs/layout.md            -> key: "cogos/docs/layout.md"
 ```
+
+The key keeps the original filename suffix.
 
 Files under `cogos/includes/` are automatically prepended to every process's system prompt by the executor.
 
@@ -133,14 +135,14 @@ Files can reference other files inline with `@{...}`. The context engine resolve
 
 ```python
 # In a process definition, use @{...} to reference a file
-add_process("my-agent", content="@{agents/my-agent}", ...)
+add_process("my-agent", content="@{agents/my-agent.md}", ...)
 ```
 
-The file at `agents/my-agent` might contain:
+The file at `agents/my-agent.md` might contain:
 
 ```md
-@{whoami/index}
-@{cogos/includes/code_mode}
+@{whoami/index.md}
+@{cogos/includes/code_mode.md}
 ```
 
 Those references are expanded directly where they appear when building the prompt.
@@ -188,7 +190,7 @@ Via image (preferred for stable configuration):
 add_process(
     "data-sync",
     mode="daemon",
-    content="@{agents/data-sync}",
+    content="@{agents/data-sync.md}",
     runner="lambda",
     priority=5.0,
     capabilities=["files", "channels", "procs"],
@@ -580,7 +582,7 @@ All under `/api/cogents/{name}/`:
 Or update at runtime via capability:
 
 ```python
-files.write("agents/my-agent", "updated prompt content")
+files.write("agents/my-agent.md", "updated prompt content")
 ```
 
 ### Cost Control

--- a/images/cogent-v1/files/cogos/docs/fs.md
+++ b/images/cogent-v1/files/cogos/docs/fs.md
@@ -7,28 +7,29 @@ CogOS uses a versioned, hierarchical key-value store for all persistent data. Fi
 Files are identified by string keys that look like paths:
 
 ```
-whoami/index
-cogos/docs/layout
-cogos/lib/scheduler
+whoami/index.md
+cogos/docs/layout.md
+cogos/lib/scheduler.md
 ```
 
 Keys are hierarchical — you can list files by prefix (`dir.list("cogos/docs/")`).
+Use the exact stored key, including suffixes such as `.md` and `.json`. Do not strip suffixes from `@{...}` references.
 
 ## Versioning
 
 Every write creates a new version. Old versions are never overwritten.
 
 ```python
-files.write("config/system", "v1 content")   # version 1
-files.write("config/system", "v2 content")   # version 2
-files.read("config/system")                   # returns version 2
+files.write("config/system.json", "v1 content")  # version 1
+files.write("config/system.json", "v2 content")  # version 2
+files.read("config/system.json")                 # returns version 2
 ```
 
 Use `file_version` capability to access history:
 
 ```python
-versions = file_version.list("config/system")  # all versions
-old = file_version.get("config/system", version=1)
+versions = file_version.list("config/system.json")  # all versions
+old = file_version.get("config/system.json", version=1)
 ```
 
 ## Three file capabilities
@@ -46,7 +47,7 @@ old = file_version.get("config/system", version=1)
 Files can reference other files inline with `@{file-key}`. The context engine resolves those references recursively, depth-first, and concatenates them into the prompt.
 
 ```md
-# agents/my-agent
+# agents/my-agent.md
 @{whoami/index.md}
 @{cogos/includes/code_mode.md}
 ```

--- a/images/cogent-v1/files/cogos/docs/layout.md
+++ b/images/cogent-v1/files/cogos/docs/layout.md
@@ -45,14 +45,14 @@ You can read and write any file you have capability for. CogOS is designed for s
 
 ```python
 # Read your own docs
-layout = files.read("cogos/docs/layout")
+layout = files.read("cogos/docs/layout.md")
 print(layout.content)
 
 # Update a process prompt
-files.write("cogos/lib/scheduler", new_scheduler_prompt)
+files.write("cogos/lib/scheduler.md", new_scheduler_prompt)
 
 # Add a new include
-files.write("cogos/includes/my_tool", "# My Tool\n...")
+files.write("cogos/includes/my_tool.md", "# My Tool\n...")
 ```
 
 Every write creates a new version. Old versions are preserved and accessible via `file_version`.

--- a/images/cogent-v1/files/cogos/includes/code_mode.md
+++ b/images/cogent-v1/files/cogos/includes/code_mode.md
@@ -24,4 +24,5 @@ Execute Python in the sandbox. Capability objects are pre-injected as top-level 
 - Use `search()` to discover capabilities beyond what's in scope.
 - You can run multiple statements in one `run_code` call.
 - Errors return the full traceback — read it and fix your code.
-- Read `cogos/docs/layout` for file organization. Read `cogos/docs/*` for how CogOS works.
+- Read `cogos/docs/layout.md` for file organization.
+- Use `dir.list("cogos/docs/")` to discover other docs, and read them by full key including the `.md` suffix.

--- a/images/cogent-v1/files/cogos/includes/files.md
+++ b/images/cogent-v1/files/cogos/includes/files.md
@@ -2,6 +2,8 @@
 
 Three capabilities for file access: `file` (single key), `dir` (prefix), `file_version` (history).
 
+Use exact file keys, including suffixes like `.md` and `.json`. Inline prompt references should also keep the suffix: `@{cogos/docs/layout.md}`, not `@{cogos/docs/layout}`.
+
 ## dir — directory access
 
 ```python
@@ -11,14 +13,14 @@ for e in entries:
     print(e.key)
 
 # Read a file
-doc = dir.read("cogos/docs/layout")
+doc = dir.read("cogos/docs/layout.md")
 print(doc.content)
 
 # Write a file (creates or updates)
-dir.write("workspace/notes", "my notes here")
+dir.write("workspace/notes.md", "my notes here")
 
 # Delete a file
-dir.delete("workspace/old-notes")
+dir.delete("workspace/old-notes.md")
 ```
 
 **Scoping:** `dir.scope(prefix="/workspace/", ops=["list", "read"])`
@@ -27,35 +29,35 @@ dir.delete("workspace/old-notes")
 
 ```python
 # Read
-content = file.read("/config/system")
+content = file.read("/config/system.md")
 print(content.content)
 
 # Write
-file.write("/config/system", "new config")
+file.write("/config/system.md", "new config")
 
 # Delete
-file.delete("/config/system")
+file.delete("/config/system.md")
 
 # Metadata (versions, timestamps)
-meta = file.get_metadata("/config/system")
+meta = file.get_metadata("/config/system.md")
 print(meta.versions, meta.created_at)
 ```
 
-**Scoping:** `file.scope(key="/config/system", ops=["read"])`
+**Scoping:** `file.scope(key="/config/system.md", ops=["read"])`
 
 ## file_version — version history
 
 ```python
 # List all versions of a file
-versions = file_version.list("/config/system")
+versions = file_version.list("/logs/audit.md")
 for v in versions:
     print(f"v{v.version}: {v.source} — {len(v.content)} chars")
 
 # Add a new version
-file_version.add("/config/system", "updated content")
+file_version.add("/logs/audit.md", "updated content")
 ```
 
-**Scoping:** `file_version.scope(key="/logs/audit", ops=["add"])`
+**Scoping:** `file_version.scope(key="/logs/audit.md", ops=["add"])`
 
 ## Return types
 

--- a/images/cogent-v1/files/whoami/index.md
+++ b/images/cogent-v1/files/whoami/index.md
@@ -18,4 +18,4 @@ You are a general-purpose cogent. Your job is to handle tasks assigned to you by
 
 - Your runtime is CogOS. You have capabilities (tools), files (persistent documents), and memory.
 - You are scheduled by the CogOS scheduler daemon, which dispatches processes based on channel messages and priority.
-- You can read your own files for context. Start with `whoami/` for identity, `cogos/docs/layout` for file organization, and `cogos/docs/*` for how CogOS works.
+- You can read your own files for context. Start with `whoami/index.md` for identity, `cogos/docs/layout.md` for file organization, and `dir.list("cogos/docs/")` to find other docs by full key.

--- a/tests/cogos/test_image_apply.py
+++ b/tests/cogos/test_image_apply.py
@@ -14,13 +14,13 @@ def _make_spec() -> ImageSpec:
              "metadata": {"description": "Concurrent Lambda slots"}},
         ],
         processes=[
-            {"name": "scheduler", "mode": "daemon", "content": "@{cogos/scheduler}",
+            {"name": "scheduler", "mode": "daemon", "content": "@{cogos/scheduler.md}",
              "runner": "lambda", "model": None,
              "priority": 100.0, "capabilities": ["dir"],
              "handlers": [], "metadata": {}},
         ],
         cron_rules=[],
-        files={"cogos/scheduler": "You are the scheduler."},
+        files={"cogos/scheduler.md": "You are the scheduler."},
     )
 
 
@@ -39,7 +39,7 @@ def test_apply_creates_files(tmp_path):
     spec = _make_spec()
     apply_image(spec, repo)
 
-    f = repo.get_file_by_key("cogos/scheduler")
+    f = repo.get_file_by_key("cogos/scheduler.md")
     assert f is not None
     fv = repo.get_active_file_version(f.id)
     assert fv.content == "You are the scheduler."

--- a/tests/cogos/test_image_snapshot.py
+++ b/tests/cogos/test_image_snapshot.py
@@ -15,13 +15,13 @@ def test_snapshot_round_trips(tmp_path):
         ],
         resources=[],
         processes=[
-            {"name": "scheduler", "mode": "daemon", "content": "@{cogos/scheduler}",
+            {"name": "scheduler", "mode": "daemon", "content": "@{cogos/scheduler.md}",
              "runner": "lambda", "model": None,
              "priority": 100.0, "capabilities": ["dir"],
              "handlers": [], "metadata": {}},
         ],
         cron_rules=[],
-        files={"cogos/scheduler": "You are the scheduler."},
+        files={"cogos/scheduler.md": "You are the scheduler."},
     )
     apply_image(original, repo)
 
@@ -31,7 +31,7 @@ def test_snapshot_round_trips(tmp_path):
     # Verify files were generated
     assert (snapshot_dir / "init" / "capabilities.py").exists()
     assert (snapshot_dir / "init" / "processes.py").exists()
-    assert (snapshot_dir / "files" / "cogos" / "scheduler").exists()
+    assert (snapshot_dir / "files" / "cogos" / "scheduler.md").exists()
     assert (snapshot_dir / "README.md").exists()
 
     # Round-trip: load the snapshot and verify
@@ -40,7 +40,7 @@ def test_snapshot_round_trips(tmp_path):
     assert restored.capabilities[0]["name"] == "dir"
     assert len(restored.processes) == 1
     assert restored.processes[0]["name"] == "scheduler"
-    assert restored.processes[0]["content"] == "@{cogos/scheduler}"
+    assert restored.processes[0]["content"] == "@{cogos/scheduler.md}"
     assert "dir" in restored.processes[0]["capabilities"]
     assert restored.processes[0]["handlers"] == []
-    assert restored.files["cogos/scheduler"] == "You are the scheduler."
+    assert restored.files["cogos/scheduler.md"] == "You are the scheduler."


### PR DESCRIPTION
Problem

The file-system guidance and image examples were still using a mix of suffixless and suffix-preserving file keys. That made `@{...}` references ambiguous and encouraged agents to target the wrong key form even though the stored keys keep suffixes like `.md` and `.json`.

Summary

- update the built-in file guidance and runtime context docs to always use exact file keys, including suffixes, in examples and `@{...}` references
- align the CogOS guide/design examples with the actual image loader behavior, which preserves the full filename in the stored key
- update image apply/snapshot tests to use `cogos/scheduler.md` so docs, examples, and tests all point at the same key format

Testing

- `uv run pytest tests/cogos/test_image_apply.py tests/cogos/test_image_snapshot.py tests/cogos/test_image_spec.py tests/cogos/test_image_e2e.py`
- `uv run pytest tests/cogos/test_recruiter_image.py -k 'not test_cogent_v1_recruiter_loads'`
- `uv run pytest tests/cogos/test_image_apply.py tests/cogos/test_image_snapshot.py tests/cogos/test_image_spec.py tests/cogos/test_image_e2e.py tests/cogos/test_recruiter_image.py`  
  This currently fails on `tests/cogos/test_recruiter_image.py::test_cogent_v1_recruiter_loads` on current `origin/main` because the recruiter image no longer loads `recruiter/present` during image load.
