### PR TITLE
Persist CogOS run log artifacts on failed startup

### DIFF
--- a/src/cogos/db/local_repository.py
+++ b/src/cogos/db/local_repository.py
@@ -802,11 +802,17 @@ class LocalRepository:
         delivery_id: UUID | None = None,
         *,
         error: str | None = None,
+        snapshot: dict | None = None,
     ) -> None:
         with self._writing():
             if delivery_id is not None:
                 self.requeue_delivery(delivery_id)
-            self.complete_run(run_id, status=RunStatus.FAILED, error=(error or "executor invoke failed")[:4000])
+            self.complete_run(
+                run_id,
+                status=RunStatus.FAILED,
+                error=(error or "executor invoke failed")[:4000],
+                snapshot=snapshot,
+            )
             current = self._processes.get(process_id)
             if current and current.status not in (ProcessStatus.DISABLED, ProcessStatus.SUSPENDED):
                 self.update_process_status(process_id, ProcessStatus.RUNNABLE)

--- a/src/cogos/db/repository.py
+++ b/src/cogos/db/repository.py
@@ -600,10 +600,16 @@ class Repository:
         delivery_id: UUID | None = None,
         *,
         error: str | None = None,
+        snapshot: dict | None = None,
     ) -> None:
         if delivery_id is not None:
             self.requeue_delivery(delivery_id)
-        self.complete_run(run_id, status=RunStatus.FAILED, error=(error or "executor invoke failed")[:4000])
+        self.complete_run(
+            run_id,
+            status=RunStatus.FAILED,
+            error=(error or "executor invoke failed")[:4000],
+            snapshot=snapshot,
+        )
         current = self.get_process(process_id)
         if current and current.status not in (ProcessStatus.DISABLED, ProcessStatus.SUSPENDED):
             self.update_process_status(process_id, ProcessStatus.RUNNABLE)

--- a/src/cogos/executor/handler.py
+++ b/src/cogos/executor/handler.py
@@ -20,6 +20,7 @@ from cogos.db.factory import create_repository
 from cogos.db.models import Process, ProcessStatus, Run, RunStatus
 from cogos.db.models.channel_message import ChannelMessage
 from cogos.db.repository import Repository
+from cogos.executor.log_capture import capture_executor_artifacts
 from cogos.executor.session_store import SessionStore, build_prompt_fingerprint
 from cogos.sandbox.executor import SandboxExecutor, VariableTable
 
@@ -278,45 +279,11 @@ def execute_process(
     bedrock_client: Any | None = None,
 ) -> Run:
     """Execute process via Bedrock converse API with search + run_code tool loop."""
-    bedrock = bedrock_client or boto3.client(
-        "bedrock-runtime",
-        region_name=config.region,
-        config=BotoConfig(retries={"max_attempts": 12, "mode": "adaptive"}),
-    )
-
-    # Build system prompt using the shared ContextEngine
-    from cogos.files.context_engine import ContextEngine
-    from cogos.files.store import FileStore
-    file_store = FileStore(repo)
-    ctx = ContextEngine(file_store)
-    system_prompt = ctx.generate_full_prompt(process)
-
-    if not system_prompt:
-        system_prompt = "You are a CogOS process. Follow your instructions and use capabilities to accomplish your task."
-
-    # Prepend includes — all files under "cogos/includes/" are auto-injected
-    includes_content = _load_includes(repo)
-    if includes_content:
-        system_prompt = includes_content + "\n\n" + system_prompt
-
-    system = [{"text": system_prompt}]
     model_id = process.model or config.default_model
     run.model_version = model_id
-    prompt_fingerprint = build_prompt_fingerprint(system_prompt, model_id, TOOL_CONFIG)
     session_store = SessionStore(repo)
     session = session_store.resolve_session(process, event_data, run.id)
-    loaded_checkpoint = session_store.load_checkpoint(
-        session,
-        prompt_fingerprint=prompt_fingerprint,
-        model_id=model_id,
-    )
     checkpoint_key = session.checkpoint_key if session.resume_enabled else None
-    resume_skipped_reason = loaded_checkpoint.resume_skipped_reason
-    session_store.write_manifest(
-        session,
-        latest_run_id=run.id,
-        checkpoint_key=checkpoint_key,
-    )
 
     # Build user message from the triggering event only. Process instructions
     # already live in the system prompt, including any `@{file-key}` refs.
@@ -326,15 +293,7 @@ def execute_process(
     if not user_text.strip():
         user_text = "Execute your task."
     user_message = {"role": "user", "content": [{"text": user_text}]}
-
-    messages = list(loaded_checkpoint.messages)
-    messages.append(user_message)
-    session_store.write_trigger(session, event_data=event_data, user_message=user_message)
-
-    # Set up sandbox with capability proxies
-    vt = VariableTable()
-    _setup_capability_proxies(vt, process, repo, run_id=run.id)
-    sandbox = SandboxExecutor(vt)
+    messages = [user_message]
 
     total_input_tokens = 0
     total_output_tokens = 0
@@ -347,6 +306,11 @@ def execute_process(
     tool_latency_by_name: dict[str, int] = defaultdict(int)
     final_stop_reason = "end_turn"
     step_seq = 0
+    prompt_fingerprint = ""
+    resumed = False
+    resumed_from_run_id: str | None = None
+    resume_skipped_reason: str | None = None
+    sandbox: SandboxExecutor | None = None
 
     def _record_step(step_type: str, payload: dict[str, Any], *, refresh_checkpoint: bool) -> None:
         nonlocal step_seq, checkpoint_key, resume_skipped_reason
@@ -366,189 +330,241 @@ def execute_process(
         if checkpoint_result.resume_disabled_reason is not None:
             resume_skipped_reason = checkpoint_result.resume_disabled_reason
 
-    _record_step(
-        "trigger_loaded",
-        {
-            "message": user_message,
-            "resumed": loaded_checkpoint.resumed,
-            "resumed_from_run_id": loaded_checkpoint.resumed_from_run_id,
-            "resume_skipped_reason": loaded_checkpoint.resume_skipped_reason,
-        },
-        refresh_checkpoint=True,
-    )
-
     try:
-        for _turn in range(config.max_turns):
-            turn_number = _turn + 1
-            kwargs: dict[str, Any] = {
-                "modelId": model_id,
-                "messages": messages,
-                "system": system,
-                "toolConfig": TOOL_CONFIG,
-            }
-
-            bedrock_started = time.monotonic()
-            response = bedrock.converse(**kwargs)
-            bedrock_latency_ms = int((time.monotonic() - bedrock_started) * 1000)
-            turns_executed += 1
-            bedrock_total_ms += bedrock_latency_ms
-            output_message, invalid_tool_names = _sanitize_tool_use_message(
-                response["output"]["message"],
-                run_id=run.id,
-                process_name=process.name,
-                turn_number=turn_number,
+        with capture_executor_artifacts(
+            lambda step_type, payload: _record_step(step_type, payload, refresh_checkpoint=False),
+        ):
+            session_store.write_manifest(
+                session,
+                latest_run_id=run.id,
+                checkpoint_key=checkpoint_key,
             )
-            messages.append(output_message)
+            session_store.write_trigger(session, event_data=event_data, user_message=user_message)
 
-            usage = response.get("usage", {})
-            total_input_tokens += usage.get("inputTokens", 0)
-            total_output_tokens += usage.get("outputTokens", 0)
-
-            stop_reason = response.get("stopReason", "end_turn")
-            final_stop_reason = stop_reason
-            logger.info(
-                "CogOS latency bedrock_turn=%sms run=%s process=%s turn=%s stop_reason=%s "
-                "input_tokens=%s output_tokens=%s",
-                bedrock_latency_ms,
-                run.id,
-                process.name,
-                turn_number,
-                stop_reason,
-                usage.get("inputTokens", 0),
-                usage.get("outputTokens", 0),
+            bedrock = bedrock_client or boto3.client(
+                "bedrock-runtime",
+                region_name=config.region,
+                config=BotoConfig(retries={"max_attempts": 12, "mode": "adaptive"}),
             )
+
+            # Build system prompt using the shared ContextEngine
+            from cogos.files.context_engine import ContextEngine
+            from cogos.files.store import FileStore
+
+            file_store = FileStore(repo)
+            ctx = ContextEngine(file_store)
+            system_prompt = ctx.generate_full_prompt(process)
+
+            if not system_prompt:
+                system_prompt = (
+                    "You are a CogOS process. Follow your instructions and use capabilities to accomplish your task."
+                )
+
+            # Prepend includes — all files under "cogos/includes/" are auto-injected
+            includes_content = _load_includes(repo)
+            if includes_content:
+                system_prompt = includes_content + "\n\n" + system_prompt
+
+            system = [{"text": system_prompt}]
+            prompt_fingerprint = build_prompt_fingerprint(system_prompt, model_id, TOOL_CONFIG)
+            loaded_checkpoint = session_store.load_checkpoint(
+                session,
+                prompt_fingerprint=prompt_fingerprint,
+                model_id=model_id,
+            )
+            resumed = loaded_checkpoint.resumed
+            resumed_from_run_id = loaded_checkpoint.resumed_from_run_id
+            resume_skipped_reason = loaded_checkpoint.resume_skipped_reason
+            messages = list(loaded_checkpoint.messages)
+            messages.append(user_message)
+
+            # Set up sandbox with capability proxies
+            vt = VariableTable()
+            _setup_capability_proxies(vt, process, repo, run_id=run.id)
+            sandbox = SandboxExecutor(vt)
+
             _record_step(
-                "assistant_message",
+                "trigger_loaded",
                 {
-                    "turn_number": turn_number,
-                    "message": output_message,
-                    "stop_reason": stop_reason,
-                    "input_tokens": usage.get("inputTokens", 0),
-                    "output_tokens": usage.get("outputTokens", 0),
+                    "message": user_message,
+                    "resumed": resumed,
+                    "resumed_from_run_id": resumed_from_run_id,
+                    "resume_skipped_reason": resume_skipped_reason,
                 },
                 refresh_checkpoint=True,
             )
 
-            if stop_reason == "tool_use":
-                tool_turns += 1
-                tool_results = []
-                for block in output_message.get("content", []):
-                    if "toolUse" not in block:
-                        continue
-                    tool_use = block["toolUse"]
-                    tool_use_id = tool_use.get("toolUseId", "")
-                    tool_name = tool_use.get("name", "")
-                    tool_input = tool_use.get("input", {})
-                    invalid_tool_name = invalid_tool_names.get(tool_use_id)
-                    if invalid_tool_name is not None:
-                        invalid_tool_calls += 1
-                        tool_calls += 1
-                        tool_results.append({
-                            "toolResult": {
-                                "toolUseId": tool_use_id,
-                                "content": [{
-                                    "text": (
-                                        f"Error: invalid tool name '{invalid_tool_name}'. "
-                                        f"Valid tools: {', '.join(sorted(SUPPORTED_TOOL_NAMES))}."
-                                    ),
-                                }],
-                            }
-                        })
-                        continue
-                    tool_started = time.monotonic()
+            for _turn in range(config.max_turns):
+                turn_number = _turn + 1
+                kwargs: dict[str, Any] = {
+                    "modelId": model_id,
+                    "messages": messages,
+                    "system": system,
+                    "toolConfig": TOOL_CONFIG,
+                }
 
-                    if tool_name == "search":
-                        result = _handle_search(tool_input, process, repo)
-                    elif tool_name == "run_code":
-                        result = sandbox.execute(tool_input.get("code", ""))
-                    else:
-                        result = f"Unknown tool: {tool_name}"
+                bedrock_started = time.monotonic()
+                response = bedrock.converse(**kwargs)
+                bedrock_latency_ms = int((time.monotonic() - bedrock_started) * 1000)
+                turns_executed += 1
+                bedrock_total_ms += bedrock_latency_ms
+                output_message, invalid_tool_names = _sanitize_tool_use_message(
+                    response["output"]["message"],
+                    run_id=run.id,
+                    process_name=process.name,
+                    turn_number=turn_number,
+                )
+                messages.append(output_message)
 
-                    tool_latency_ms = int((time.monotonic() - tool_started) * 1000)
-                    tool_calls += 1
-                    tool_total_ms += tool_latency_ms
-                    tool_latency_by_name[tool_name] += tool_latency_ms
-                    logger.info(
-                        "CogOS latency tool=%sms run=%s process=%s turn=%s tool=%s",
-                        tool_latency_ms,
-                        run.id,
-                        process.name,
-                        turn_number,
-                        tool_name,
-                    )
-                    tool_results.append({
-                        "toolResult": {
-                            "toolUseId": tool_use["toolUseId"],
-                            "content": [{"text": result}],
-                        }
-                    })
-                tool_result_message = {"role": "user", "content": tool_results}
-                messages.append(tool_result_message)
+                usage = response.get("usage", {})
+                total_input_tokens += usage.get("inputTokens", 0)
+                total_output_tokens += usage.get("outputTokens", 0)
+
+                stop_reason = response.get("stopReason", "end_turn")
+                final_stop_reason = stop_reason
+                logger.info(
+                    "CogOS latency bedrock_turn=%sms run=%s process=%s turn=%s stop_reason=%s "
+                    "input_tokens=%s output_tokens=%s",
+                    bedrock_latency_ms,
+                    run.id,
+                    process.name,
+                    turn_number,
+                    stop_reason,
+                    usage.get("inputTokens", 0),
+                    usage.get("outputTokens", 0),
+                )
                 _record_step(
-                    "tool_results_appended",
+                    "assistant_message",
                     {
                         "turn_number": turn_number,
-                        "message": tool_result_message,
+                        "message": output_message,
+                        "stop_reason": stop_reason,
+                        "input_tokens": usage.get("inputTokens", 0),
+                        "output_tokens": usage.get("outputTokens", 0),
                     },
                     refresh_checkpoint=True,
                 )
-                continue
 
-            break
-        else:
-            final_stop_reason = "max_turns"
+                if stop_reason == "tool_use":
+                    tool_turns += 1
+                    tool_results = []
+                    for block in output_message.get("content", []):
+                        if "toolUse" not in block:
+                            continue
+                        tool_use = block["toolUse"]
+                        tool_use_id = tool_use.get("toolUseId", "")
+                        tool_name = tool_use.get("name", "")
+                        tool_input = tool_use.get("input", {})
+                        invalid_tool_name = invalid_tool_names.get(tool_use_id)
+                        if invalid_tool_name is not None:
+                            invalid_tool_calls += 1
+                            tool_calls += 1
+                            tool_results.append({
+                                "toolResult": {
+                                    "toolUseId": tool_use_id,
+                                    "content": [{
+                                        "text": (
+                                            f"Error: invalid tool name '{invalid_tool_name}'. "
+                                            f"Valid tools: {', '.join(sorted(SUPPORTED_TOOL_NAMES))}."
+                                        ),
+                                    }],
+                                }
+                            })
+                            continue
+                        tool_started = time.monotonic()
 
-        run.tokens_in = total_input_tokens
-        run.tokens_out = total_output_tokens
-        run.scope_log = sandbox.scope_log
-        _record_step(
-            "final_stop",
-            {
-                "status": RunStatus.COMPLETED.value,
-                "final_stop_reason": final_stop_reason,
-                "tokens_in": total_input_tokens,
-                "tokens_out": total_output_tokens,
-            },
-            refresh_checkpoint=True,
-        )
-        run.snapshot = session_store.finalize_run(
-            session,
-            status=RunStatus.COMPLETED.value,
-            resumed=loaded_checkpoint.resumed,
-            resumed_from_run_id=loaded_checkpoint.resumed_from_run_id,
-            resume_skipped_reason=resume_skipped_reason,
-            final_stop_reason=final_stop_reason,
-            error=None,
-            last_completed_step=step_seq,
-            message_count=len(messages),
-            checkpoint_key=checkpoint_key,
-        )
-        logger.info(
-            "CogOS execution breakdown run=%s process=%s model=%s turns=%s final_stop_reason=%s "
-            "bedrock_calls=%s tool_turns=%s tool_calls=%s invalid_tool_calls=%s "
-            "bedrock_total_ms=%s tool_total_ms=%s "
-            "search_ms=%s run_code_ms=%s tokens_in=%s tokens_out=%s",
-            run.id,
-            process.name,
-            model_id,
-            turns_executed,
-            final_stop_reason,
-            turns_executed,
-            tool_turns,
-            tool_calls,
-            invalid_tool_calls,
-            bedrock_total_ms,
-            tool_total_ms,
-            tool_latency_by_name.get("search", 0),
-            tool_latency_by_name.get("run_code", 0),
-            total_input_tokens,
-            total_output_tokens,
-        )
+                        if tool_name == "search":
+                            result = _handle_search(tool_input, process, repo)
+                        elif tool_name == "run_code":
+                            result = sandbox.execute(tool_input.get("code", ""))
+                        else:
+                            result = f"Unknown tool: {tool_name}"
+
+                        tool_latency_ms = int((time.monotonic() - tool_started) * 1000)
+                        tool_calls += 1
+                        tool_total_ms += tool_latency_ms
+                        tool_latency_by_name[tool_name] += tool_latency_ms
+                        logger.info(
+                            "CogOS latency tool=%sms run=%s process=%s turn=%s tool=%s",
+                            tool_latency_ms,
+                            run.id,
+                            process.name,
+                            turn_number,
+                            tool_name,
+                        )
+                        tool_results.append({
+                            "toolResult": {
+                                "toolUseId": tool_use["toolUseId"],
+                                "content": [{"text": result}],
+                            }
+                        })
+                    tool_result_message = {"role": "user", "content": tool_results}
+                    messages.append(tool_result_message)
+                    _record_step(
+                        "tool_results_appended",
+                        {
+                            "turn_number": turn_number,
+                            "message": tool_result_message,
+                        },
+                        refresh_checkpoint=True,
+                    )
+                    continue
+
+                break
+            else:
+                final_stop_reason = "max_turns"
+
+            run.tokens_in = total_input_tokens
+            run.tokens_out = total_output_tokens
+            run.scope_log = sandbox.scope_log
+            _record_step(
+                "final_stop",
+                {
+                    "status": RunStatus.COMPLETED.value,
+                    "final_stop_reason": final_stop_reason,
+                    "tokens_in": total_input_tokens,
+                    "tokens_out": total_output_tokens,
+                },
+                refresh_checkpoint=True,
+            )
+            run.snapshot = session_store.finalize_run(
+                session,
+                status=RunStatus.COMPLETED.value,
+                resumed=resumed,
+                resumed_from_run_id=resumed_from_run_id,
+                resume_skipped_reason=resume_skipped_reason,
+                final_stop_reason=final_stop_reason,
+                error=None,
+                last_completed_step=step_seq,
+                message_count=len(messages),
+                checkpoint_key=checkpoint_key,
+            )
+            logger.info(
+                "CogOS execution breakdown run=%s process=%s model=%s turns=%s final_stop_reason=%s "
+                "bedrock_calls=%s tool_turns=%s tool_calls=%s invalid_tool_calls=%s "
+                "bedrock_total_ms=%s tool_total_ms=%s "
+                "search_ms=%s run_code_ms=%s tokens_in=%s tokens_out=%s",
+                run.id,
+                process.name,
+                model_id,
+                turns_executed,
+                final_stop_reason,
+                turns_executed,
+                tool_turns,
+                tool_calls,
+                invalid_tool_calls,
+                bedrock_total_ms,
+                tool_total_ms,
+                tool_latency_by_name.get("search", 0),
+                tool_latency_by_name.get("run_code", 0),
+                total_input_tokens,
+                total_output_tokens,
+            )
         return run
     except Exception as exc:
         run.tokens_in = total_input_tokens
         run.tokens_out = total_output_tokens
-        run.scope_log = sandbox.scope_log
+        run.scope_log = sandbox.scope_log if sandbox is not None else []
         final_stop_reason = "exception"
         _record_step(
             "final_stop",
@@ -564,8 +580,8 @@ def execute_process(
         run.snapshot = session_store.finalize_run(
             session,
             status=RunStatus.FAILED.value,
-            resumed=loaded_checkpoint.resumed,
-            resumed_from_run_id=loaded_checkpoint.resumed_from_run_id,
+            resumed=resumed,
+            resumed_from_run_id=resumed_from_run_id,
             resume_skipped_reason=resume_skipped_reason,
             final_stop_reason=final_stop_reason,
             error=str(exc)[:4000],

--- a/src/cogos/executor/log_capture.py
+++ b/src/cogos/executor/log_capture.py
@@ -1,0 +1,108 @@
+"""Mirror executor runtime output into session artifact steps."""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from typing import Callable, Iterator
+
+_FORMATTER = logging.Formatter()
+
+
+class _ArtifactLoggingHandler(logging.Handler):
+    def __init__(
+        self,
+        record_step: Callable[[str, dict], None],
+        *,
+        excluded_prefixes: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__()
+        self._record_step = record_step
+        self._excluded_prefixes = excluded_prefixes
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if any(record.name.startswith(prefix) for prefix in self._excluded_prefixes):
+            return
+        try:
+            payload = {
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+            }
+            if record.exc_info:
+                payload["exception"] = _FORMATTER.formatException(record.exc_info)
+            self._record_step("executor_log", payload)
+        except Exception:
+            self.handleError(record)
+
+
+class _LineBufferedTee(io.TextIOBase):
+    def __init__(self, stream, sink: Callable[[str], None]) -> None:  # noqa: ANN001
+        self._stream = stream
+        self._sink = sink
+        self._buffer = ""
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._stream, "encoding", "utf-8")
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, data: str) -> int:
+        text = str(data)
+        self._stream.write(text)
+        self._buffer += text
+        self._flush_complete_lines()
+        return len(text)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def finish(self) -> None:
+        if self._buffer:
+            line = self._buffer.rstrip("\r\n")
+            self._buffer = ""
+            if line:
+                self._sink(line)
+        self.flush()
+
+    def _flush_complete_lines(self) -> None:
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            line = line.rstrip("\r")
+            if line:
+                self._sink(line)
+
+
+@contextmanager
+def capture_executor_artifacts(
+    record_step: Callable[[str, dict], None],
+    *,
+    min_log_level: int = logging.INFO,
+) -> Iterator[None]:
+    """Capture runtime logger/stdout/stderr output as artifact steps."""
+    root_logger = logging.getLogger()
+    previous_level = root_logger.level
+    if previous_level > min_log_level:
+        root_logger.setLevel(min_log_level)
+
+    log_handler = _ArtifactLoggingHandler(
+        record_step,
+        excluded_prefixes=("cogos.executor.log_capture", "cogos.executor.session_store"),
+    )
+    root_logger.addHandler(log_handler)
+
+    stdout_tee = _LineBufferedTee(sys.stdout, lambda line: record_step("executor_stdout", {"message": line}))
+    stderr_tee = _LineBufferedTee(sys.stderr, lambda line: record_step("executor_stderr", {"message": line}))
+
+    try:
+        with redirect_stdout(stdout_tee), redirect_stderr(stderr_tee):
+            yield
+    finally:
+        stdout_tee.finish()
+        stderr_tee.finish()
+        root_logger.removeHandler(log_handler)
+        root_logger.setLevel(previous_level)

--- a/src/cogos/runtime/ingress.py
+++ b/src/cogos/runtime/ingress.py
@@ -7,10 +7,68 @@ import logging
 from typing import Any
 from uuid import UUID
 
+from cogos.executor.session_store import SessionStore
 from cogos.db.models import ProcessStatus
 from cogos.runtime.dispatch import build_dispatch_event
 
 logger = logging.getLogger(__name__)
+
+
+def _persist_dispatch_failure_artifacts(
+    repo,
+    process,
+    event_data: dict[str, Any],
+    run_id: UUID,
+    *,
+    error: str,
+    executor_function_name: str,
+) -> dict[str, Any] | None:
+    session_store = SessionStore(repo)
+
+    try:
+        session = session_store.resolve_session(process, event_data, run_id)
+        checkpoint_key = session.checkpoint_key if session.resume_enabled else None
+        session_store.write_manifest(
+            session,
+            latest_run_id=run_id,
+            checkpoint_key=checkpoint_key,
+        )
+        session_store.write_trigger(
+            session,
+            event_data=event_data,
+            user_message={
+                "role": "user",
+                "content": [{"text": "Executor dispatch failed before the run started."}],
+            },
+        )
+        session_store.write_step(
+            session,
+            seq=1,
+            step_type="dispatch_failed",
+            payload={
+                "status": "failed",
+                "final_stop_reason": "dispatch_error",
+                "error": error[:4000],
+                "executor_function_name": executor_function_name,
+                "message_id": event_data.get("message_id"),
+                "payload": event_data.get("payload"),
+            },
+        )
+        return session_store.finalize_run(
+            session,
+            status="failed",
+            resumed=False,
+            resumed_from_run_id=None,
+            resume_skipped_reason="executor_not_started",
+            final_stop_reason="dispatch_error",
+            error=error[:4000],
+            last_completed_step=1,
+            message_count=1,
+            checkpoint_key=checkpoint_key,
+        )
+    except Exception:
+        logger.exception("Failed to persist dispatch failure artifacts for run %s", run_id)
+        return None
 
 
 def dispatch_ready_processes(
@@ -44,11 +102,20 @@ def dispatch_ready_processes(
                 raise RuntimeError(f"unexpected lambda invoke status {response.get('StatusCode')}")
             dispatched += 1
         except Exception as exc:
+            snapshot = _persist_dispatch_failure_artifacts(
+                repo,
+                proc,
+                payload,
+                UUID(dispatch_result.run_id),
+                error=str(exc),
+                executor_function_name=executor_function_name,
+            )
             repo.rollback_dispatch(
                 process_id,
                 UUID(dispatch_result.run_id),
                 UUID(dispatch_result.delivery_id) if dispatch_result.delivery_id else None,
                 error=str(exc),
+                snapshot=snapshot,
             )
             logger.exception("Failed to invoke executor for process %s", process_id)
 

--- a/tests/cogos/test_executor_handler.py
+++ b/tests/cogos/test_executor_handler.py
@@ -369,7 +369,10 @@ def test_stateless_process_writes_session_artifacts_and_snapshot(monkeypatch, tm
     assert final_artifact["final_stop_reason"] == "end_turn"
     assert final_artifact["resume_skipped_reason"] is None
     assert manifest["latest_run_id"] == str(run.id)
-    assert len(step_files) == 3
+    step_types = [_read_json(store, file.key)["type"] for file in step_files]
+    assert step_types.count("trigger_loaded") == 1
+    assert step_types.count("assistant_message") == 1
+    assert step_types.count("final_stop") == 1
 
 
 def test_process_session_loads_previous_checkpoint(monkeypatch, tmp_path):

--- a/tests/cogos/test_scheduler_ingress.py
+++ b/tests/cogos/test_scheduler_ingress.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from cogos.capabilities.scheduler import SchedulerCapability
 from cogos.db.local_repository import LocalRepository
 from cogos.db.models import Channel, ChannelMessage, ChannelType, Cron, DeliveryStatus, Handler, Process, ProcessMode, ProcessStatus, RunStatus
+from cogos.files.store import FileStore
 from cogos.runtime.schedule import apply_scheduled_messages
 from cogtainer.lambdas.dispatcher.handler import _apply_system_ticks
 from cogos.runtime.ingress import dispatch_ready_processes
@@ -128,6 +129,12 @@ def test_dispatch_rolls_back_failed_invoke(tmp_path):
     runs = repo.list_runs(process_id=proc.id)
     assert len(runs) == 1
     assert runs[0].status == RunStatus.FAILED
+    assert runs[0].snapshot is not None
+    final_key = runs[0].snapshot["final_key"]
+    store = FileStore(repo)
+    final_payload = store.get_content(final_key)
+    assert final_payload is not None
+    assert "dispatch_error" in final_payload
     delivery = next(iter(repo._deliveries.values()))
     assert delivery.status == DeliveryStatus.PENDING
     assert delivery.run is None

--- a/tests/dashboard/test_runs_logs.py
+++ b/tests/dashboard/test_runs_logs.py
@@ -6,9 +6,13 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
+from cogos.capabilities.scheduler import SchedulerCapability
 from cogos.db.local_repository import LocalRepository
-from cogos.db.models import Process, ProcessMode, ProcessStatus, Run, RunStatus
+from cogos.db.models import Channel, ChannelMessage, ChannelType, Handler, Process, ProcessMode, ProcessStatus, Run, RunStatus
+from cogos.executor import handler as executor_handler
 from cogos.files.store import FileStore
+from cogos.runtime.ingress import dispatch_ready_processes
+from cogos.runtime.local import run_and_complete
 from dashboard.app import create_app
 
 
@@ -190,3 +194,152 @@ def test_run_logs_endpoint_without_session_artifacts_returns_empty(tmp_path):
         "entries": [],
         "error": None,
     }
+
+
+def test_run_logs_endpoint_returns_dispatch_failure_artifacts(tmp_path):
+    repo = LocalRepository(str(tmp_path))
+    process = Process(
+        id=uuid4(),
+        name="alpha.worker",
+        mode=ProcessMode.DAEMON,
+        status=ProcessStatus.WAITING,
+        runner="lambda",
+    )
+    repo.upsert_process(process)
+
+    channel = Channel(name="io:test", channel_type=ChannelType.NAMED)
+    repo.upsert_channel(channel)
+    channel = repo.get_channel_by_name("io:test")
+    repo.create_handler(Handler(process=process.id, channel=channel.id))
+    repo.append_channel_message(ChannelMessage(channel=channel.id, payload={"content": "hello"}))
+
+    scheduler = SchedulerCapability(repo, uuid4())
+
+    class _LambdaClient:
+        def invoke(self, **_kwargs):
+            raise RuntimeError("invoke throttled")
+
+    dispatched = dispatch_ready_processes(
+        repo,
+        scheduler,
+        _LambdaClient(),
+        "executor-fn",
+        {process.id},
+    )
+
+    assert dispatched == 0
+    run = repo.list_runs(process_id=process.id)[0]
+    assert run.snapshot is not None
+
+    app = create_app()
+    client = TestClient(app)
+
+    with patch("dashboard.routers.runs.get_repo", return_value=repo):
+        response = client.get(f"/api/cogents/test/runs/{run.id}/logs")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["log_group"] == "CogOS session artifacts"
+    assert payload["log_stream"] is not None
+    assert len(payload["entries"]) == 4
+    assert "trigger" in payload["entries"][0]["message"]
+    assert "dispatch_failed" in payload["entries"][1]["message"]
+    assert "invoke throttled" in payload["entries"][1]["message"]
+    assert "final | status=failed | stop=dispatch_error" in payload["entries"][2]["message"]
+    assert "manifest | latest_run=" in payload["entries"][3]["message"]
+
+
+def test_run_logs_endpoint_returns_pre_turn_failure_artifacts(monkeypatch, tmp_path):
+    repo = LocalRepository(str(tmp_path))
+    process = Process(
+        id=uuid4(),
+        name="alpha.worker",
+        mode=ProcessMode.ONE_SHOT,
+        status=ProcessStatus.RUNNING,
+        runner="local",
+    )
+    repo.upsert_process(process)
+
+    run = Run(id=uuid4(), process=process.id, status=RunStatus.RUNNING)
+    repo.create_run(run)
+
+    monkeypatch.setattr(executor_handler, "_load_includes", lambda _repo: (_ for _ in ()).throw(RuntimeError("include boom")))
+
+    run_and_complete(
+        process,
+        {"payload": {"content": "hello"}},
+        run,
+        executor_handler.ExecutorConfig(max_turns=1),
+        repo,
+        bedrock_client=object(),
+    )
+
+    stored_run = repo.get_run(run.id)
+    assert stored_run is not None
+    assert stored_run.status == RunStatus.FAILED
+    assert stored_run.duration_ms is not None
+    assert stored_run.snapshot is not None
+
+    app = create_app()
+    client = TestClient(app)
+
+    with patch("dashboard.routers.runs.get_repo", return_value=repo):
+        response = client.get(f"/api/cogents/test/runs/{run.id}/logs")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["log_group"] == "CogOS session artifacts"
+    assert payload["log_stream"] is not None
+    assert len(payload["entries"]) == 4
+    assert "trigger" in payload["entries"][0]["message"]
+    assert "final_stop | stop=exception" in payload["entries"][1]["message"]
+    assert "include boom" in payload["entries"][1]["message"]
+    assert "final | status=failed | stop=exception" in payload["entries"][2]["message"]
+    assert "manifest | latest_run=" in payload["entries"][3]["message"]
+
+
+def test_run_logs_endpoint_captures_executor_logger_output(monkeypatch, tmp_path):
+    repo = LocalRepository(str(tmp_path))
+    process = Process(
+        id=uuid4(),
+        name="secret-audit/scout/manual-1735000000",
+        mode=ProcessMode.ONE_SHOT,
+        status=ProcessStatus.RUNNING,
+        runner="local",
+        content="@{apps/secret-audit/config.json}\n@{apps/secret-audit/heuristics.md}",
+    )
+    repo.upsert_process(process)
+
+    run = Run(id=uuid4(), process=process.id, status=RunStatus.RUNNING)
+    repo.create_run(run)
+
+    monkeypatch.setattr(executor_handler, "_load_includes", lambda _repo: "")
+
+    class _Bedrock:
+        def converse(self, **_kwargs):
+            return {
+                "output": {"message": {"role": "assistant", "content": [{"text": "done"}]}},
+                "usage": {"inputTokens": 3, "outputTokens": 2},
+                "stopReason": "end_turn",
+            }
+
+    run_and_complete(
+        process,
+        {"payload": {"content": "hello"}},
+        run,
+        executor_handler.ExecutorConfig(max_turns=1),
+        repo,
+        bedrock_client=_Bedrock(),
+    )
+
+    app = create_app()
+    client = TestClient(app)
+
+    with patch("dashboard.routers.runs.get_repo", return_value=repo):
+        response = client.get(f"/api/cogents/test/runs/{run.id}/logs?limit=100")
+
+    assert response.status_code == 200
+    payload = response.json()
+    messages = [entry["message"] for entry in payload["entries"]]
+    assert any("cannot read prompt reference apps/secret-audit/config.json" in message for message in messages)
+    assert any("cannot read prompt reference apps/secret-audit/heuristics.md" in message for message in messages)


### PR DESCRIPTION
Problem

Runs that failed before the executor emitted a step or before Lambda invoke succeeded showed an empty run-log preview in the dashboard, even though we intended those logs to live in the file store. We also had no general way to surface executor logger/stdout output like prompt reference warnings without adding bespoke artifact writes.

Summary

- persist synthetic session artifacts when dispatch fails before the executor starts
- write trigger and final failure artifacts before prompt construction and first Bedrock turn so early executor failures still appear in run logs
- mirror executor logger records and stdout/stderr into session artifact steps so dashboard run logs include generic runtime output such as prompt reference warnings
- cover dispatch failure, pre-turn failure, and executor logger capture in regression tests

Testing

- uv run pytest tests/dashboard/test_runs_logs.py tests/cogos/test_executor_handler.py tests/cogos/test_scheduler_ingress.py