### PR TITLE
consolidate deploy docs, fix stale references

### DIFF
--- a/.claude/commands/deploy.cogos.md
+++ b/.claude/commands/deploy.cogos.md
@@ -1,5 +1,7 @@
 Deploy CogOS changes (image data, DB schema, executor logic) with minimal disruption.
 
+Human-readable reference: [docs/deploy.md](../../docs/deploy.md)
+
 ## Pre-flight
 
 1. Ensure no uncommitted changes: `git status --porcelain` must be empty. If dirty, stop and ask.

--- a/.claude/commands/deploy.cogtainer.md
+++ b/.claude/commands/deploy.cogtainer.md
@@ -1,5 +1,7 @@
 Deploy cogtainer infrastructure changes (CDK stack, Lambda, ECS, RDS).
 
+Human-readable reference: [docs/deploy.md](../../docs/deploy.md)
+
 This is the heaviest deploy — only use when actual infrastructure changes are needed.
 
 ## Pre-flight

--- a/.claude/commands/deploy.dashboard.md
+++ b/.claude/commands/deploy.dashboard.md
@@ -1,5 +1,7 @@
 Deploy dashboard changes with minimal disruption.
 
+Human-readable reference: [docs/deploy.md](../../docs/deploy.md)
+
 ## Pre-flight
 
 1. Ensure no uncommitted changes: `git status --porcelain` must be empty. If dirty, stop and ask.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,11 +152,15 @@ cogent dr.alpha dashboard deploy --docker     # Force Docker image rebuild
 
 This builds the Next.js static export, packages it with the FastAPI backend into a Docker image, pushes to ECR (`901289084804.dkr.ecr.us-east-1.amazonaws.com/cogent`), and restarts the ECS Fargate service. The dashboard is served at `https://{safe-name}.softmax-cogents.com`.
 
-### Deploying brain (Lambda + DB migrations)
+### Deploying Lambda + DB migrations
+
+See [docs/deploy.md](docs/deploy.md) for the full deploy reference.
 
 ```bash
-cogent dr.alpha brain update                  # Update Lambda code + run DB migrations
-cogent dr.alpha brain update stack            # Update CloudFormation stack (ALB rules, etc.)
+cogent dr.alpha cogtainer update lambda       # Update Lambda code (~15s)
+cogent dr.alpha cogtainer update rds          # Run DB schema migrations
+cogent dr.alpha cogtainer update all          # Lambda + RDS + sync
+cogent dr.alpha cogtainer create --watch      # Full CDK stack deploy (ALB rules, IAM, etc.)
 ```
 
 ### Managing the Discord bridge (remote)
@@ -174,7 +178,7 @@ cogent dr.alpha cogos io discord status    # Check running/desired counts
 
 ```bash
 cogent dr.alpha dashboard create-pat
-cogent dr.alpha brain update stack            # Apply ALB bypass rule
+cogent dr.alpha cogtainer create --watch      # Apply ALB bypass rule
 ```
 
 2. Test with curl:

--- a/docs/cogtainer/README.md
+++ b/docs/cogtainer/README.md
@@ -18,13 +18,17 @@ PostgreSQL (16 tables, JSONB metadata, LISTEN/NOTIFY)
 src/cogtainer/
 ├── __init__.py          # Package root
 ├── cli.py               # CogTainer CLI group (status/create/destroy)
-├── update_cli.py        # Update subcommands (lambda/discord/ecs/rds/stack/docker)
-└── db/
-    ├── __init__.py      # Public API exports
-    ├── models.py        # Pydantic models + enums
-    ├── repository.py    # Async Repository
-    ├── local_repository.py  # JSON-file local dev repository
-    └── migrations.py    # Schema apply/reset
+├── update_cli.py        # Update subcommands (lambda/ecs/rds/stack/dashboard)
+├── cdk/                 # CDK infrastructure definitions
+├── db/
+│   ├── __init__.py      # Public API exports
+│   ├── models.py        # Pydantic models + enums
+│   ├── repository.py    # Async Repository (RDS Data API)
+│   ├── local_repository.py  # JSON-file local dev repository
+│   └── migrations.py    # Schema apply/reset
+├── docker/              # Dockerfile and Docker build context
+├── lambdas/             # Lambda function handlers (orchestrator, executor, dispatcher, ingress)
+└── tools/               # Build and deploy tooling
 ```
 
 The database schema DDL lives in `src/cogos/db/schema.sql`.
@@ -44,6 +48,10 @@ repo = LocalRepository()
 
 ## Tables
 
+Both legacy (cogtainer-layer, from `schema.sql`) and CogOS tables (from `src/cogos/db/migrations/`) coexist in the database.
+
+### Legacy / Cogtainer Tables (`schema.sql`)
+
 | Table | Purpose |
 |-------|---------|
 | `schema_version` | Migration tracking |
@@ -62,6 +70,30 @@ repo = LocalRepository()
 | `events` | Append-only event log with causal chains |
 | `alerts` | Algedonic emergency system |
 | `budget` | Token/cost accounting by period |
+
+### CogOS Tables (migrations)
+
+| Table | Purpose |
+|-------|---------|
+| `cogos_file` | CogOS file store |
+| `cogos_file_version` | File content versions |
+| `cogos_capability` | Capability definitions |
+| `cogos_process` | Process definitions and state |
+| `cogos_process_capability` | Process-capability associations |
+| `cogos_handler` | Event handlers |
+| `cogos_event` | CogOS event log |
+| `cogos_event_type` | Event type registry |
+| `cogos_event_delivery` | Event delivery tracking |
+| `cogos_event_outbox` | Outbound event queue |
+| `cogos_run` | CogOS execution runs |
+| `cogos_trace` | CogOS execution traces |
+| `cogos_meta` | CogOS metadata key-value store |
+| `cogos_schema` | Schema definitions |
+| `cogos_channel` | Communication channels |
+| `cogos_channel_message` | Channel message history |
+| `cogos_ingress_wake` | Ingress wake tracking |
+| `cogos_discord_guild` | Discord guild metadata |
+| `cogos_discord_channel` | Discord channel metadata |
 
 ## CLI
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,125 @@
+# Deploy Guide
+
+Single reference for deploying Cogent components. For operational runbooks used by Claude, see `.claude/commands/deploy.*.md`.
+
+## Architecture
+
+Four deployable components:
+
+| Component | Infrastructure | Deploy tool |
+|-----------|---------------|-------------|
+| **Lambda functions** | orchestrator, executor, dispatcher, ingress | `cogtainer update lambda` |
+| **Database schema** | Aurora PostgreSQL via RDS Data API | `cogtainer update rds` |
+| **Dashboard** | ECS Fargate on cogent-polis cluster | `dashboard deploy` |
+| **CDK stack** | All infrastructure definitions (IAM, VPC, ALB, ECS task defs) | `cogtainer create --watch` |
+
+## Decision Tree
+
+What changed? Run `git diff HEAD~1 --name-only` and match:
+
+| Changed paths | Command |
+|---|---|
+| `images/**` | `cogent <name> cogos image boot cogent-v1` |
+| `src/cogos/executor/**`, `src/cogos/sandbox/**` | `cogent <name> cogtainer update lambda` |
+| `src/cogos/capabilities/**` | `cogent <name> cogtainer update lambda` + `cogos image boot cogent-v1` |
+| `src/cogos/db/migrations/**` | `cogent <name> cogtainer update rds` |
+| `dashboard/frontend/**` | `cogent <name> dashboard deploy` |
+| `src/dashboard/**` | `cogent <name> dashboard deploy --docker` |
+| Both frontend + backend | `cogent <name> dashboard deploy --docker` |
+| `src/cogtainer/cdk/**`, IAM, VPC, ALB changes | `cogent <name> cogtainer create --watch` |
+| `DOCKER_VERSION` changed | `cogent <name> cogtainer create --watch` |
+
+## Command Reference
+
+### Lambda + DB
+
+```bash
+cogent <name> cogtainer update lambda       # Update Lambda code only (~15s)
+cogent <name> cogtainer update rds          # Run DB schema migrations
+cogent <name> cogtainer update ecs          # Force new ECS deployment (restart containers)
+cogent <name> cogtainer update all          # Lambda + RDS migrations + sync
+```
+
+### CDK Stack
+
+```bash
+cogent <name> cogtainer create --watch      # Full CDK deploy (~3-5 min)
+cogent <name> cogtainer build               # Build + push executor Docker image to ECR
+cogent <name> cogtainer status              # Check infrastructure status
+```
+
+### Image
+
+```bash
+cogent <name> cogos image boot cogent-v1          # Upsert capabilities, files, processes into DB
+cogent <name> cogos image boot cogent-v1 --clean  # Wipe all tables first, then boot
+```
+
+### Dashboard
+
+```bash
+cogent <name> dashboard deploy              # Fast path: Next.js build -> S3 -> restart ECS (~30s)
+cogent <name> dashboard deploy --docker     # Full path: rebuild Docker image + push ECR + restart
+cogent <name> dashboard deploy --skip-health  # Skip health check wait
+```
+
+### Discord Bridge
+
+```bash
+cogent <name> cogos io discord start        # Scale ECS service to 1 task
+cogent <name> cogos io discord stop         # Scale to 0
+cogent <name> cogos io discord restart      # Force new deployment
+cogent <name> cogos io discord status       # Check running/desired counts
+```
+
+## Typical Sequences
+
+**Image-only change** (edited files in `images/`):
+```bash
+cogent <name> cogos image boot cogent-v1
+```
+
+**Executor code change** (`src/cogos/executor/`, `src/cogos/sandbox/`):
+```bash
+cogent <name> cogtainer update lambda
+cogent <name> cogos image boot cogent-v1    # if image also changed
+```
+
+**Schema migration + executor change**:
+```bash
+cogent <name> cogtainer update rds
+cogent <name> cogtainer update lambda
+cogent <name> cogos image boot cogent-v1
+```
+
+**Dashboard frontend-only**:
+```bash
+cogent <name> dashboard deploy
+```
+
+**Dashboard with backend changes**:
+```bash
+cogent <name> dashboard deploy --docker
+```
+
+**Full infrastructure change** (CDK constructs, IAM, ALB):
+```bash
+cogent <name> cogtainer create --watch
+cogent <name> cogos image boot cogent-v1
+```
+
+**Docker image change** (Dockerfile, new deps):
+```bash
+cogent <name> cogtainer build
+cogent <name> cogtainer update ecs
+```
+
+## Post-Deploy Verification
+
+```bash
+cogent <name> cogtainer status              # Infrastructure health
+cogent <name> cogos status                  # CogOS status
+cogent <name> cogos process list            # Processes running
+```
+
+For dashboard, open `https://<safe-name>.softmax-cogents.com` and confirm the change is visible.

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "httpx" },
     { name = "pillow" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygithub" },
@@ -546,6 +547,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "pillow", specifier = ">=10.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pygithub", specifier = ">=2.0" },
@@ -1361,6 +1363,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2171,6 +2185,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Create docs/deploy.md as single deploy reference
- Fix brain update references in AGENTS.md to cogtainer update
- Update cogtainer README with full table list (legacy + cogos)
- Link deploy skill files to new deploy guide

Co-Authored-By: Claude <noreply@anthropic.com>