### PR TITLE
fix init process: add anthropic to Lambda deps

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -53,6 +53,8 @@ cogent <name> cogtainer status              # Check infrastructure status
 ```bash
 cogent <name> cogos image boot cogent-v1          # Upsert capabilities, files, processes into DB
 cogent <name> cogos image boot cogent-v1 --clean  # Wipe all tables first, then boot
+cogent <name> cogos reload -i cogent-v1 -y        # Reload config from image, preserving runtime data
+cogent <name> cogos reload -i cogent-v1 -y --full # Wipe ALL data (including runtime) and reload
 ```
 
 ### Dashboard
@@ -61,6 +63,7 @@ cogent <name> cogos image boot cogent-v1 --clean  # Wipe all tables first, then 
 cogent <name> dashboard deploy              # Fast path: Next.js build -> S3 -> restart ECS (~30s)
 cogent <name> dashboard deploy --docker     # Full path: rebuild Docker image + push ECR + restart
 cogent <name> dashboard deploy --skip-health  # Skip health check wait
+cogent <name> cogos dashboard reload          # Restart local dashboard (stop + start)
 ```
 
 ### Discord Bridge

--- a/src/cogtainer/update_cli.py
+++ b/src/cogtainer/update_cli.py
@@ -102,7 +102,7 @@ def _package_lambda_code() -> bytes:
     deps_dir = tempfile.mkdtemp(prefix="lambda-deps-")
     lambda_deps = [
         "pydantic", "pydantic-settings", "pydantic-core", "annotated-types",
-        "Pillow", "google-genai",
+        "Pillow", "google-genai", "anthropic",
     ]
     subprocess.check_call(
         [


### PR DESCRIPTION
## Summary
- **Add `anthropic` package to Lambda deployment deps** — the LLM fallback path (Bedrock -> Anthropic API) was silently broken because the `anthropic` pip package wasn't included in the Lambda zip. When Bedrock hit its daily token throttle, the fallback raised an ImportError instead of serving requests.
- **Document missing CLI commands** in deploy.md — `cogos reload` (with `--full` flag) and `cogos dashboard reload` were undocumented.

## Test plan
- [x] Deployed updated Lambda to dr.gamma (`cogtainer update lambda`), confirmed package size increased from 16.7MB to 17.5MB
- [x] Verified Anthropic fallback activates when Bedrock throttles (previously raised `ModuleNotFoundError: No module named 'anthropic'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)