### PR TITLE
Add web capability to Discord handler

### DIFF
--- a/images/cogent-v1/apps/discord/discord.md
+++ b/images/cogent-v1/apps/discord/discord.md
@@ -25,7 +25,7 @@ if not has_handler:
         model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
         capabilities=[
             "discord", "channels", "stdlib", "procs", "file",
-            "image", "blob", "secrets",
+            "image", "blob", "secrets", "web",
             {"name": "dir", "alias": "data", "config": {"prefix": "data/discord/"}},
         ],
         idle_timeout_ms=300000,

--- a/images/cogent-v1/apps/discord/handler/main.md
+++ b/images/cogent-v1/apps/discord/handler/main.md
@@ -6,8 +6,9 @@ You are the Discord message handler for dr.alpha. Process the message in the pay
 
 - `json` is pre-loaded. **Do NOT use `import`** — it does not exist.
 - Variables **persist** between `run_code` calls.
-- Available objects: `discord`, `channels`, `data` (dir), `file`, `stdlib`, `procs`, `image`, `blob`, `secrets`.
+- Available objects: `discord`, `channels`, `data` (dir), `file`, `stdlib`, `procs`, `image`, `blob`, `secrets`, `web`.
 - `data` is a directory scoped to `data/discord/`. Use `data.get("key")` to get a file handle, then `.read()`, `.write(content)`, `.append(text)`.
+- `web` lets you publish websites: `web.publish(path, content)` publishes HTML/CSS/JS at `web/{path}`. `web.list()` shows published files. `web.unpublish(path)` removes a file. Published pages are available at the cogent's web URL.
 - Use `stdlib.time.time()` for timestamps. Use `stdlib.time.strftime(...)` for formatting.
 - Pydantic models: access fields with `.field_name`, not `.get("field_name")`.
 
@@ -92,6 +93,7 @@ print("Done")
 - General knowledge questions (time, greetings, simple facts)
 - System questions you CAN answer: use `procs.list()` for processes, `channels.list()` for channels
 - Simple conversation
+- User asks you to build/create a website or web page — use `web.publish(path, html_content)` to publish it, then share the link
 
 **Escalate** when:
 - User needs a capability you don't have (email, web search, github, asana)


### PR DESCRIPTION
## Summary
- Adds the `web` capability to the Discord handler's daemon spawn config
- Documents `web.publish()`, `web.list()`, and `web.unpublish()` in the handler prompt
- Teaches the handler to build/publish websites when users ask via Discord messages

## Test plan
- [ ] Verify Discord handler daemon spawns with `web` capability
- [ ] Send a Discord message asking to create a website and confirm it publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)