### PR TITLE
Add persistent trace filters and stable refresh UX

### DIFF
--- a/dashboard/frontend/src/components/traces/TracePanel.tsx
+++ b/dashboard/frontend/src/components/traces/TracePanel.tsx
@@ -33,9 +33,17 @@ const RUN_STATUS_VARIANT: Record<string, BadgeVariant> = {
   suspended: "neutral",
 };
 
-const ALL_FILTER_VALUE = "__all__";
 const UNTYPED_FILTER_VALUE = "__untyped__";
 const FILTER_FETCH_LIMIT = 100;
+const TRACE_FILTERS_STORAGE_PREFIX = "cogent.trace-panel.filters:";
+
+const MESSAGE_CATEGORIES = ["system", "io", "other"] as const;
+type MessageCategory = (typeof MESSAGE_CATEGORIES)[number];
+
+interface PersistedTraceFilters {
+  searchQuery?: string;
+  hiddenCategories?: MessageCategory[];
+}
 
 function shortId(value: string | null | undefined): string {
   if (!value) return "--";
@@ -68,17 +76,46 @@ function displayMessageType(messageType: string | null | undefined): string {
   return normalizeMessageType(messageType) === UNTYPED_FILTER_VALUE ? "untyped" : String(messageType);
 }
 
-function addTypeCount(counts: Map<string, number>, messageType: string | null | undefined) {
-  const key = normalizeMessageType(messageType);
-  counts.set(key, (counts.get(key) ?? 0) + 1);
+function displayTraceId(traceId: string | null | undefined): string | null {
+  return traceId?.trim() ? traceId : null;
 }
 
-function sortTypeEntries(counts: Map<string, number>): Array<[string, number]> {
-  return Array.from(counts.entries()).sort(([left], [right]) => {
-    if (left === UNTYPED_FILTER_VALUE) return 1;
-    if (right === UNTYPED_FILTER_VALUE) return -1;
-    return left.localeCompare(right);
-  });
+function isMessageCategory(value: string): value is MessageCategory {
+  return (MESSAGE_CATEGORIES as readonly string[]).includes(value);
+}
+
+function traceFiltersStorageKey(cogentName: string): string {
+  return `${TRACE_FILTERS_STORAGE_PREFIX}${cogentName}`;
+}
+
+function loadPersistedTraceFilters(cogentName: string): PersistedTraceFilters | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(traceFiltersStorageKey(cogentName));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedTraceFilters;
+    return {
+      searchQuery: typeof parsed.searchQuery === "string" ? parsed.searchQuery : "",
+      hiddenCategories: Array.isArray(parsed.hiddenCategories)
+        ? parsed.hiddenCategories.filter((value): value is MessageCategory => typeof value === "string" && isMessageCategory(value))
+        : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function persistTraceFilters(cogentName: string, filters: PersistedTraceFilters) {
+  if (typeof window === "undefined") return;
+  const next: PersistedTraceFilters = {
+    searchQuery: filters.searchQuery?.trim() ? filters.searchQuery : "",
+    hiddenCategories: filters.hiddenCategories?.filter(isMessageCategory) ?? [],
+  };
+  if (!next.searchQuery && (next.hiddenCategories?.length ?? 0) === 0) {
+    window.localStorage.removeItem(traceFiltersStorageKey(cogentName));
+    return;
+  }
+  window.localStorage.setItem(traceFiltersStorageKey(cogentName), JSON.stringify(next));
 }
 
 function safeJson(value: unknown): string {
@@ -139,6 +176,8 @@ function traceSearchBlob(trace: MessageTrace): string {
   const parts: string[] = [
     trace.message.channel_name,
     trace.message.message_type ?? "",
+    trace.message.request_id ?? "",
+    trace.message.trace_id ?? "",
     trace.message.sender_process_name ?? "",
     trace.message.sender_process ?? "",
     payloadPreview(trace.message.payload),
@@ -159,6 +198,8 @@ function traceSearchBlob(trace: MessageTrace): string {
       parts.push(
         emitted.channel_name,
         emitted.message_type ?? "",
+        emitted.request_id ?? "",
+        emitted.trace_id ?? "",
         payloadPreview(emitted.payload),
         safeJson(emitted.payload),
       );
@@ -197,6 +238,7 @@ function TraceMessageCard({
           <Badge variant="info">{message.channel_name}</Badge>
           <MessageTypeBadge messageType={message.message_type} />
           <span>message {shortId(message.id)}</span>
+          {displayTraceId(message.trace_id) && <span>trace {shortId(message.trace_id)}</span>}
           <span>sender {message.sender_process_name ?? message.sender_process ?? "external"}</span>
           <span>{fmtTimestamp(message.created_at)}</span>
         </div>
@@ -223,11 +265,22 @@ function TraceMessageCard({
   );
 }
 
+function LoadingSpinner({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
+      <span
+        aria-hidden="true"
+        className="h-3 w-3 animate-spin rounded-full border-2 border-[var(--border)] border-t-[var(--accent)]"
+      />
+      <span>{label}</span>
+    </span>
+  );
+}
+
 export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePanelProps) {
   const [expandedMessageIds, setExpandedMessageIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedMessageType, setSelectedMessageType] = useState(ALL_FILTER_VALUE);
-  const [selectedEmittedMessageType, setSelectedEmittedMessageType] = useState(ALL_FILTER_VALUE);
+  const [hiddenCategories, setHiddenCategories] = useState<Set<MessageCategory>>(new Set());
   const [filteredTraceResults, setFilteredTraceResults] = useState<MessageTrace[] | null>(null);
   const [filterLoading, setFilterLoading] = useState(false);
   const [filterError, setFilterError] = useState<string | null>(null);
@@ -240,8 +293,26 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
   const [composerSuccess, setComposerSuccess] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const skipNextChannelAutofill = useRef(false);
+  const skipNextFilterPersist = useRef(true);
+  const hasServerFilters = hiddenCategories.size > 0;
 
-  const hasServerFilters = selectedMessageType !== ALL_FILTER_VALUE || selectedEmittedMessageType !== ALL_FILTER_VALUE;
+  useEffect(() => {
+    skipNextFilterPersist.current = true;
+    const persisted = loadPersistedTraceFilters(cogentName);
+    setSearchQuery(persisted?.searchQuery ?? "");
+    setHiddenCategories(new Set(persisted?.hiddenCategories ?? []));
+  }, [cogentName]);
+
+  useEffect(() => {
+    if (skipNextFilterPersist.current) {
+      skipNextFilterPersist.current = false;
+      return;
+    }
+    persistTraceFilters(cogentName, {
+      searchQuery,
+      hiddenCategories: Array.from(hiddenCategories),
+    });
+  }, [cogentName, hiddenCategories, searchQuery]);
 
   useEffect(() => {
     let cancelled = false;
@@ -288,8 +359,7 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
       setFilterError(null);
       try {
         const next = await api.getMessageTraces(cogentName, timeRange, {
-          messageTypes: selectedMessageType === ALL_FILTER_VALUE ? [] : [selectedMessageType],
-          emittedMessageTypes: selectedEmittedMessageType === ALL_FILTER_VALUE ? [] : [selectedEmittedMessageType],
+          categories: MESSAGE_CATEGORIES.filter((c) => !hiddenCategories.has(c)),
           limit: FILTER_FETCH_LIMIT,
         });
         if (!cancelled) {
@@ -297,7 +367,6 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
         }
       } catch (error) {
         if (!cancelled) {
-          setFilteredTraceResults([]);
           setFilterError(error instanceof Error ? error.message : "Could not load filtered traces.");
         }
       } finally {
@@ -312,29 +381,9 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
     return () => {
       cancelled = true;
     };
-  }, [cogentName, hasServerFilters, selectedEmittedMessageType, selectedMessageType, timeRange, traces]);
+  }, [cogentName, hasServerFilters, hiddenCategories, timeRange, traces]);
 
-  const sourceTypeCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const trace of traces) {
-      addTypeCount(counts, trace.message.message_type);
-    }
-    return sortTypeEntries(counts);
-  }, [traces]);
-
-  const emittedTypeCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const trace of traces) {
-      for (const delivery of trace.deliveries) {
-        for (const emitted of delivery.emitted_messages) {
-          addTypeCount(counts, emitted.message_type);
-        }
-      }
-    }
-    return sortTypeEntries(counts);
-  }, [traces]);
-
-  const traceSource = hasServerFilters ? (filteredTraceResults ?? []) : traces;
+  const traceSource = hasServerFilters ? (filteredTraceResults ?? traces) : traces;
   const sendableChannels = useMemo(
     () => channels.filter((channel) => channel.channel_type === "named" && !channel.closed_at),
     [channels],
@@ -424,8 +473,19 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
 
   const clearFilters = () => {
     setSearchQuery("");
-    setSelectedMessageType(ALL_FILTER_VALUE);
-    setSelectedEmittedMessageType(ALL_FILTER_VALUE);
+    setHiddenCategories(new Set());
+  };
+
+  const toggleCategory = (category: MessageCategory) => {
+    setHiddenCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
   };
 
   const clearComposer = () => {
@@ -482,7 +542,7 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
   const emptyMessage = hasAnyFilters
     ? "No channel message traces matched the current filters."
     : "No channel message traces in this time window.";
-  const showLoadingState = hasServerFilters && filterLoading && filteredTraceResults === null;
+  const showLoadingState = hasServerFilters && filterLoading && traceSource.length === 0;
   const canSend = !!selectedChannelId && payloadValidation.error === null && !sending && !channelsLoading;
 
   return (
@@ -626,15 +686,12 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
       </div>
 
       <div className="rounded-md border border-[var(--border)] bg-[var(--bg-surface)] p-4 space-y-3">
-        <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_220px_220px_auto]">
-          <div className="space-y-1">
-            <label className="block text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
-              Search
-            </label>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex-1 min-w-[200px]">
             <input
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="channel, sender, type, payload"
+              placeholder="search channel, sender, type, payload..."
               className="w-full rounded-md border px-3 py-2 text-[12px] font-mono"
               style={{
                 background: "var(--bg-base)",
@@ -644,81 +701,58 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
             />
           </div>
 
-          <div className="space-y-1">
-            <label className="block text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
-              Message Type
-            </label>
-            <select
-              value={selectedMessageType}
-              onChange={(event) => setSelectedMessageType(event.target.value)}
-              className="w-full rounded-md border px-3 py-2 text-[12px] font-mono"
-              style={{
-                background: "var(--bg-base)",
-                borderColor: "var(--border)",
-                color: "var(--text-primary)",
-              }}
-            >
-              <option value={ALL_FILTER_VALUE}>all types</option>
-              {sourceTypeCounts.map(([type, count]) => (
-                <option key={type} value={type}>
-                  {displayMessageType(type)} ({count})
-                </option>
-              ))}
-            </select>
+          <div className="flex items-center gap-1.5">
+            {MESSAGE_CATEGORIES.map((cat) => {
+              const hidden = hiddenCategories.has(cat);
+              return (
+                <button
+                  key={cat}
+                  type="button"
+                  onClick={() => toggleCategory(cat)}
+                  className="rounded-full border px-3 py-1.5 text-[11px] font-medium font-mono transition-colors"
+                  style={{
+                    background: hidden ? "transparent" : "var(--bg-deep)",
+                    borderColor: "var(--border)",
+                    color: hidden ? "var(--text-muted)" : "var(--text-primary)",
+                    opacity: hidden ? 0.4 : 1,
+                    textDecoration: hidden ? "line-through" : "none",
+                  }}
+                >
+                  {cat}
+                </button>
+              );
+            })}
           </div>
 
-          <div className="space-y-1">
-            <label className="block text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
-              Emits Type
-            </label>
-            <select
-              value={selectedEmittedMessageType}
-              onChange={(event) => setSelectedEmittedMessageType(event.target.value)}
-              className="w-full rounded-md border px-3 py-2 text-[12px] font-mono"
-              style={{
-                background: "var(--bg-base)",
-                borderColor: "var(--border)",
-                color: "var(--text-primary)",
-              }}
-            >
-              <option value={ALL_FILTER_VALUE}>all emitted types</option>
-              {emittedTypeCounts.map(([type, count]) => (
-                <option key={type} value={type}>
-                  {displayMessageType(type)} ({count})
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="flex items-end">
-            <button
-              type="button"
-              onClick={clearFilters}
-              disabled={!hasAnyFilters}
-              className="rounded-md border px-3 py-2 text-[11px] font-medium uppercase tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-              style={{
-                background: "transparent",
-                borderColor: "var(--border)",
-                color: "var(--text-muted)",
-              }}
-            >
-              Clear
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={clearFilters}
+            disabled={!hasAnyFilters}
+            className="rounded-md border px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              background: "transparent",
+              borderColor: "var(--border)",
+              color: "var(--text-muted)",
+            }}
+          >
+            Clear
+          </button>
         </div>
 
         <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
-          <span>{traceSource.length} trace{traceSource.length === 1 ? "" : "s"} in view</span>
-          {hasServerFilters && <Badge variant="accent">server filtered</Badge>}
+          <span>{visibleTraces.length} trace{visibleTraces.length === 1 ? "" : "s"} in view</span>
+          {hiddenCategories.size > 0 && <Badge variant="accent">hiding {Array.from(hiddenCategories).join(", ")}</Badge>}
           {hasClientFilters && <Badge variant="info">search filtered</Badge>}
-          {filterLoading && <span>Updating filtered traces...</span>}
+          {filterLoading && <LoadingSpinner label="Updating results..." />}
           {filterError && <span className="text-red-400">{filterError}</span>}
         </div>
       </div>
 
       {showLoadingState && (
         <div className="rounded-md border border-[var(--border)] bg-[var(--bg-surface)] px-4 py-8 text-center text-[12px] text-[var(--text-muted)]">
-          Loading filtered traces...
+          <div className="flex items-center justify-center">
+            <LoadingSpinner label="Loading filtered traces..." />
+          </div>
         </div>
       )}
 
@@ -750,6 +784,9 @@ export function TracePanel({ traces, cogentName, timeRange, onRefresh }: TracePa
                   <div className="flex flex-wrap items-center gap-2">
                     <Badge variant="info">{message.channel_name}</Badge>
                     <MessageTypeBadge messageType={message.message_type} />
+                    {displayTraceId(message.trace_id) && (
+                      <Badge variant="neutral">trace {shortId(message.trace_id)}</Badge>
+                    )}
                     <span className="text-[11px] text-[var(--text-muted)] font-mono">{shortId(message.id)}</span>
                     <span className="text-[11px] text-[var(--text-muted)]">
                       {message.sender_process_name ?? message.sender_process ?? "external sender"}

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -23,6 +23,8 @@ import type {
 interface MessageTraceFilters {
   messageTypes?: string[];
   emittedMessageTypes?: string[];
+  categories?: string[];
+  requestIds?: string[];
   limit?: number;
 }
 
@@ -60,6 +62,12 @@ export async function getMessageTraces(
   }
   for (const value of filters.emittedMessageTypes ?? []) {
     params.append("emitted_message_type", value);
+  }
+  for (const value of filters.categories ?? []) {
+    params.append("category", value);
+  }
+  for (const value of filters.requestIds ?? []) {
+    params.append("request_id", value);
   }
   if (filters.limit != null) {
     params.set("limit", String(filters.limit));

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -228,6 +228,8 @@ export interface TraceMessage {
   channel_id: string;
   channel_name: string;
   message_type: string | null;
+  trace_id: string | null;
+  request_id: string | null;
   sender_process: string | null;
   sender_process_name: string | null;
   payload: Record<string, unknown>;

--- a/src/dashboard/routers/traces.py
+++ b/src/dashboard/routers/traces.py
@@ -29,6 +29,8 @@ class TraceMessageOut(BaseModel):
     channel_id: str
     channel_name: str
     message_type: str | None = None
+    trace_id: str | None = None
+    request_id: str | None = None
     sender_process: str | None = None
     sender_process_name: str | None = None
     payload: dict[str, Any]
@@ -115,6 +117,33 @@ def _message_type(message: ChannelMessage) -> str | None:
     return None
 
 
+def _request_id(message: ChannelMessage) -> str | None:
+    payload = message.payload or {}
+    value = payload.get("request_id")
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized:
+            return normalized
+    return None
+
+
+def _message_category(message: ChannelMessage, *, channel_names: dict[UUID, str]) -> str:
+    channel_name = channel_names.get(message.channel, "")
+    if channel_name.startswith("io:"):
+        return "io"
+    if channel_name.startswith(("system:", "process:")):
+        return "system"
+
+    mt = _message_type(message)
+    if mt:
+        if mt.startswith(("discord:", "email:", "web:")):
+            return "io"
+        if mt.startswith(("system:", "process:")):
+            return "system"
+
+    return "other"
+
+
 def _normalize_type_filters(values: list[str] | None) -> set[str]:
     if not values:
         return set()
@@ -128,6 +157,24 @@ def _matches_type_filter(message: ChannelMessage, allowed_types: set[str]) -> bo
     return message_type in allowed_types
 
 
+def _matches_category_filter(
+    message: ChannelMessage,
+    allowed_categories: set[str],
+    *,
+    channel_names: dict[UUID, str],
+) -> bool:
+    if not allowed_categories:
+        return True
+    return _message_category(message, channel_names=channel_names) in allowed_categories
+
+
+def _matches_request_filter(message: ChannelMessage, allowed_request_ids: set[str]) -> bool:
+    if not allowed_request_ids:
+        return True
+    request_id = _request_id(message)
+    return request_id in allowed_request_ids
+
+
 def _message_out(
     message: ChannelMessage,
     *,
@@ -139,6 +186,8 @@ def _message_out(
         channel_id=str(message.channel),
         channel_name=channel_names.get(message.channel, str(message.channel)),
         message_type=_message_type(message),
+        trace_id=str(message.trace_id) if message.trace_id else None,
+        request_id=_request_id(message),
         sender_process=str(message.sender_process) if message.sender_process else None,
         sender_process_name=process_names.get(message.sender_process) if message.sender_process else None,
         payload=message.payload or {},
@@ -207,6 +256,8 @@ def list_message_traces(
     range: TraceRange = Query("1h"),
     message_type: list[str] | None = Query(None),
     emitted_message_type: list[str] | None = Query(None),
+    category: list[str] | None = Query(None),
+    request_id: list[str] | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
 ) -> MessageTracesResponse:
     repo = get_repo()
@@ -214,7 +265,12 @@ def list_message_traces(
     cutoff = datetime.now(timezone.utc) - _RANGE_TO_DELTA[range]
     source_type_filters = _normalize_type_filters(message_type)
     emitted_type_filters = _normalize_type_filters(emitted_message_type)
-    fetch_limit = max(limit * 20, 1000) if source_type_filters or emitted_type_filters else max(limit * 10, 500)
+    category_filters = _normalize_type_filters(category)
+    request_id_filters = _normalize_type_filters(request_id)
+    has_filters = source_type_filters or emitted_type_filters or category_filters or request_id_filters
+    fetch_limit = max(limit * 20, 1000) if has_filters else max(limit * 10, 500)
+    if request_id_filters:
+        fetch_limit = max(fetch_limit, 5000)
 
     processes = repo.list_processes(limit=1000)
     channels = repo.list_channels()
@@ -239,6 +295,10 @@ def list_message_traces(
         if created_at is not None and created_at < cutoff:
             continue
         if not _matches_type_filter(message, source_type_filters):
+            continue
+        if not _matches_category_filter(message, category_filters, channel_names=channel_names):
+            continue
+        if not _matches_request_filter(message, request_id_filters):
             continue
         if message.sender_process is None or deliveries_by_message.get(message.id):
             candidate_messages.append(message)

--- a/tests/dashboard/test_routers_traces.py
+++ b/tests/dashboard/test_routers_traces.py
@@ -26,6 +26,8 @@ from dashboard.app import create_app
 class _TraceRepoStub:
     def __init__(self) -> None:
         now = datetime.now(timezone.utc)
+        self.request_id = "req-123"
+        self.trace_id = uuid4()
         self.process = Process(
             id=uuid4(),
             name="alpha.worker",
@@ -48,7 +50,12 @@ class _TraceRepoStub:
             id=uuid4(),
             channel=self.inbound_channel.id,
             sender_process=None,
-            payload={"task": "index workspace", "message_type": "filesystem:index.request"},
+            payload={
+                "task": "index workspace",
+                "message_type": "filesystem:index.request",
+                "request_id": self.request_id,
+            },
+            trace_id=self.trace_id,
             created_at=now,
         )
         self.handler = Handler(
@@ -137,6 +144,8 @@ def test_message_traces_endpoint_returns_channel_delivery_run_graph():
     trace = payload["traces"][0]
     assert trace["message"]["channel_name"] == "filesystem-lab:requests"
     assert trace["message"]["message_type"] == "filesystem:index.request"
+    assert trace["message"]["request_id"] == repo.request_id
+    assert trace["message"]["trace_id"] == str(repo.trace_id)
     assert trace["deliveries"][0]["process_name"] == "alpha.worker"
     assert trace["deliveries"][0]["run"]["id"] == str(repo.run.id)
     assert trace["deliveries"][0]["emitted_messages"][0]["message_type"] == "process:run:success"
@@ -181,6 +190,53 @@ def test_message_traces_endpoint_filters_by_emitted_message_type():
 
     assert response.status_code == 200
     assert response.json()["count"] == 0
+
+
+def test_message_traces_endpoint_filters_by_request_id():
+    app = create_app()
+    client = TestClient(app)
+    repo = _TraceRepoStub()
+
+    with patch("dashboard.routers.traces.get_repo", return_value=repo):
+        response = client.get(f"/api/cogents/test/message-traces?range=1h&request_id={repo.request_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["traces"][0]["message"]["id"] == str(repo.message.id)
+
+    with patch("dashboard.routers.traces.get_repo", return_value=repo):
+        response = client.get("/api/cogents/test/message-traces?range=1h&request_id=req-missing")
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+def test_message_traces_endpoint_maps_category_filters_to_dashboard_buckets():
+    app = create_app()
+    client = TestClient(app)
+
+    other_repo = _TraceRepoStub()
+    with patch("dashboard.routers.traces.get_repo", return_value=other_repo):
+        response = client.get("/api/cogents/test/message-traces?range=1h&category=other")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+    io_repo = _TraceRepoStub()
+    io_repo.inbound_channel.name = "io:web:request"
+    io_repo.message.payload = {"request_id": io_repo.request_id, "path": "docs"}
+    with patch("dashboard.routers.traces.get_repo", return_value=io_repo):
+        response = client.get("/api/cogents/test/message-traces?range=1h&category=io")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+    system_repo = _TraceRepoStub()
+    system_repo.inbound_channel.name = "system:tick:minute"
+    system_repo.message.payload = {"type": "system:tick:minute"}
+    with patch("dashboard.routers.traces.get_repo", return_value=system_repo):
+        response = client.get("/api/cogents/test/message-traces?range=1h&category=system")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
 
 
 def test_runs_endpoint_maps_message_id_into_legacy_event_field():


### PR DESCRIPTION
Problem
The trace panel cleared out while server-side filters were reloading, which made it hard to tell whether the dashboard was still working or had simply dropped the current result set.

The trace filter state also reset on reload, so operators had to rebuild the same view repeatedly while debugging a cogent.

The category pills were targeting the wrong buckets for real trace traffic because they followed raw message-type prefixes instead of the dashboard's intended `system` / `io` / `other` semantics.

Summary
- Keep the current trace results mounted while a new filtered response is loading, and show an inline spinner instead of blanking the panel.
- Persist the trace panel search text and category pill state in local storage per cogent so the usual filter view survives reloads.
- Align the category pill filtering with real dashboard trace traffic and surface trace metadata in the trace response/UI plumbing.

Testing
- npm run type-check
- uv run pytest tests/dashboard/test_routers_traces.py -q
- uv run pytest tests/dashboard -q