### PR TITLE
Fix local alerts repository limit signature

### DIFF
--- a/src/cogos/db/local_repository.py
+++ b/src/cogos/db/local_repository.py
@@ -1188,11 +1188,11 @@ class LocalRepository:
         with self._writing():
             self._alerts[alert.id] = alert
 
-    def list_alerts(self, *, resolved: bool = False) -> list:
+    def list_alerts(self, *, resolved: bool = False, limit: int = 50) -> list:
         self._maybe_reload()
         from cogos.db.models.alert import Alert
 
         alerts = list(self._alerts.values())
         if not resolved:
             alerts = [a for a in alerts if a.resolved_at is None]
-        return sorted(alerts, key=lambda a: a.created_at or datetime.min, reverse=True)
+        return sorted(alerts, key=lambda a: a.created_at or datetime.min, reverse=True)[:limit]


### PR DESCRIPTION
Problem
The dashboard alerts router calls `list_alerts(resolved=..., limit=...)` for both the SQL repository and the local repository.

The local repository implementation did not accept `limit`, so local dashboard requests to `/api/cogents/{name}/alerts` crashed with `TypeError` instead of returning alert rows.

Summary
- Update `LocalRepository.list_alerts` to accept the same `limit` keyword argument as the SQL repository.
- Apply the limit after sorting so local dashboard alert queries follow the same router contract as prod-backed queries.

Testing
- uv run pytest /Users/nishadsingh/repos/cogents-v1-checkouts/cv2/tests/dashboard/test_routers_core.py -q
- uv run pytest /Users/nishadsingh/repos/cogents-v1-checkouts/cv2/tests/dashboard/test_integration.py -q