### PR TITLE
Serve extensionless published HTML as text/html

### DIFF
--- a/images/cogent-v1/apps/discord/discord.md
+++ b/images/cogent-v1/apps/discord/discord.md
@@ -31,10 +31,13 @@ if not has_handler:
         idle_timeout_ms=300000,
     )
     h2 = cog.make_coglet("handler")  # returns coglet handle
-    coglet_runtime.run(h2, procs, subscribe=[
+    result = coglet_runtime.run(h2, procs, subscribe=[
         "io:discord:dm", "io:discord:mention", "io:discord:message",
     ])
-    print("Handler created and started")
+    if hasattr(result, 'error'):
+        print(f"ERROR spawning handler: {result.error}")
+    else:
+        print("Handler created and started")
     exit()
 print("Handler exists, checking status...")
 ```

--- a/src/cogos/io/web/serving.py
+++ b/src/cogos/io/web/serving.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import mimetypes
+from dataclasses import dataclass
+
+HTML_PREFIXES = ("<!doctype html", "<html", "<head", "<body")
+
+
+@dataclass(frozen=True)
+class StaticWebFile:
+    key: str
+    content: str
+    content_type: str
+    is_base64: bool
+
+
+def content_type_for_path(path: str, content: str | None = None) -> str:
+    content_type, _ = mimetypes.guess_type(path)
+    if content_type:
+        return content_type
+    if content and looks_like_html(content):
+        return "text/html"
+    return "application/octet-stream"
+
+
+def looks_like_html(content: str) -> bool:
+    stripped = content.lstrip().lower()
+    return any(stripped.startswith(prefix) for prefix in HTML_PREFIXES)
+
+
+def static_file_keys(path: str) -> list[str]:
+    normalized = path.lstrip("/")
+    if not normalized:
+        return ["web/index.html"]
+    if normalized.endswith("/"):
+        return [f"web/{normalized}index.html"]
+    return [f"web/{normalized}", f"web/{normalized}/index.html"]
+
+
+def lookup_static_file(store, path: str) -> StaticWebFile | None:  # noqa: ANN001
+    for key in static_file_keys(path):
+        content = store.get_content(key)
+        if content is None:
+            continue
+        is_base64 = content.startswith("base64:")
+        body = content[7:] if is_base64 else content
+        return StaticWebFile(
+            key=key,
+            content=body,
+            content_type=content_type_for_path(key, body),
+            is_base64=is_base64,
+        )
+    return None

--- a/src/cogtainer/lambdas/web_gateway/handler.py
+++ b/src/cogtainer/lambdas/web_gateway/handler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import mimetypes
 import os
 import time
 from uuid import uuid4
@@ -12,6 +11,7 @@ import boto3
 from cogos.db.models.channel_message import ChannelMessage
 from cogos.db.repository import Repository
 from cogos.files.store import FileStore
+from cogos.io.web.serving import content_type_for_path, lookup_static_file
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +20,7 @@ _JWKS_TTL = 300
 
 
 def _content_type_for(path: str) -> str:
-    ct, _ = mimetypes.guess_type(path)
-    return ct or "application/octet-stream"
+    return content_type_for_path(path)
 
 
 def _is_api_request(path: str) -> bool:
@@ -109,22 +108,12 @@ def handler(event: dict, context=None) -> dict:
 
 def _handle_static_request(repo: Repository, path: str) -> dict:
     store = FileStore(repo)
-    file_key = _resolve_static_path(path)
-    content = store.get_content(file_key)
-
-    if content is None:
-        fallback = file_key.rstrip("/") + "/index.html"
-        content = store.get_content(fallback)
-        if content is None:
-            return _make_response(404, "not found")
-        file_key = fallback
-
-    ct = _content_type_for(file_key)
-
-    if isinstance(content, str) and content.startswith("base64:"):
-        return _make_response(200, content[7:], content_type=ct, is_base64=True)
-
-    return _make_response(200, content, content_type=ct)
+    web_file = lookup_static_file(store, path)
+    if web_file is None:
+        return _make_response(404, "not found")
+    if web_file.is_base64:
+        return _make_response(200, web_file.content, content_type=web_file.content_type, is_base64=True)
+    return _make_response(200, web_file.content, content_type=web_file.content_type)
 
 
 def _handle_api_request(

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -135,21 +137,24 @@ def create_app() -> FastAPI:
 
     # --- Web static content from FileStore (DB) ---
     def _serve_web_file(path: str) -> Response:
-        import mimetypes
-
         from cogos.files.store import FileStore
+        from cogos.io.web.serving import lookup_static_file
         from dashboard.db import get_repo
 
-        if not path or path.endswith("/"):
-            path = (path or "") + "index.html"
-
         store = FileStore(get_repo())
-        content = store.get_content(f"web/{path}")
-        if content is None:
+        web_file = lookup_static_file(store, path)
+        if web_file is None:
             return JSONResponse(status_code=404, content={"detail": "not found"})
 
-        mime, _ = mimetypes.guess_type(path)
-        return Response(content=content, media_type=mime or "application/octet-stream")
+        body: str | bytes = web_file.content
+        if web_file.is_base64:
+            try:
+                body = base64.b64decode(web_file.content, validate=True)
+            except (binascii.Error, ValueError):
+                logger.warning("Invalid base64 web content for %s", web_file.key)
+                return JSONResponse(status_code=500, content={"detail": "invalid published content"})
+
+        return Response(content=body, media_type=web_file.content_type)
 
     @app.get("/web/static")
     async def web_static_root():

--- a/tests/cogtainer/lambdas/web_gateway/test_handler.py
+++ b/tests/cogtainer/lambdas/web_gateway/test_handler.py
@@ -179,6 +179,7 @@ class TestHandlerStaticRequest:
         resp = _handle_static_request(mock_repo, "/dashboard")
         assert resp["statusCode"] == 200
         assert resp["body"] == "<html>index</html>"
+        assert resp["headers"]["content-type"] == "text/html"
         calls = mock_store.get_content.call_args_list
         assert calls[0].args[0] == "web/dashboard"
         assert calls[1].args[0] == "web/dashboard/index.html"
@@ -194,6 +195,20 @@ class TestHandlerStaticRequest:
 
         resp = _handle_static_request(mock_repo, "/nonexistent.html")
         assert resp["statusCode"] == 404
+
+    @patch("cogtainer.lambdas.web_gateway.handler.FileStore")
+    def test_extensionless_html_serves_text_html(self, mock_store_cls):
+        from cogtainer.lambdas.web_gateway.handler import _handle_static_request
+
+        mock_repo = MagicMock()
+        mock_store = MagicMock()
+        mock_store_cls.return_value = mock_store
+        mock_store.get_content.return_value = "<html>hello</html>"
+
+        resp = _handle_static_request(mock_repo, "/nature-fact")
+        assert resp["statusCode"] == 200
+        assert resp["body"] == "<html>hello</html>"
+        assert resp["headers"]["content-type"] == "text/html"
 
 
 class TestHandlerBinaryStatic:

--- a/tests/dashboard/test_app.py
+++ b/tests/dashboard/test_app.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from fastapi.testclient import TestClient
 
 from dashboard.app import create_app
@@ -9,3 +11,49 @@ def test_healthz():
     resp = client.get("/healthz")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+def test_web_static_extensionless_html_renders_in_browser():
+    app = create_app()
+    client = TestClient(app)
+
+    with patch("cogos.files.store.FileStore.get_content", return_value="<html>hello</html>"), patch(
+        "dashboard.db.get_repo", return_value=MagicMock()
+    ):
+        resp = client.get("/web/static/nature-fact")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert resp.text == "<html>hello</html>"
+
+
+def test_web_static_falls_back_to_directory_index():
+    app = create_app()
+    client = TestClient(app)
+
+    with patch(
+        "cogos.files.store.FileStore.get_content",
+        side_effect=[None, "<html>nested</html>"],
+    ) as mock_get_content, patch("dashboard.db.get_repo", return_value=MagicMock()):
+        resp = client.get("/web/static/nature-fact")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert resp.text == "<html>nested</html>"
+    calls = mock_get_content.call_args_list
+    assert calls[0].args[0] == "web/nature-fact"
+    assert calls[1].args[0] == "web/nature-fact/index.html"
+
+
+def test_web_static_decodes_base64_assets():
+    app = create_app()
+    client = TestClient(app)
+
+    with patch("cogos.files.store.FileStore.get_content", return_value="base64:iVBORw0KGgo="), patch(
+        "dashboard.db.get_repo", return_value=MagicMock()
+    ):
+        resp = client.get("/web/static/image.png")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/png")
+    assert resp.content == b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
Problem

A cogent could publish an HTML page to an extensionless path such as `nature-fact`, but both web-serving paths inferred `application/octet-stream` from the missing extension.

That made browsers download the page instead of rendering it. The dashboard route also diverged from the gateway because it did not share the same directory-index lookup or base64 asset handling.

Summary

- Share static web file lookup and content-type inference between the dashboard route and the web gateway.
- Treat extensionless published HTML as `text/html` and preserve `web/{path}` then `web/{path}/index.html` lookup semantics.
- Decode `base64:` published assets in the dashboard route and add regression coverage for extensionless HTML, directory index fallback, and binary assets.

Testing

- `uv run pytest tests/dashboard/test_app.py`
- `uv run pytest tests/cogtainer/lambdas/web_gateway/test_handler.py`