### PR TITLE
Propagate request-linked IDs through proxied web runs

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -168,6 +168,7 @@ def create_app() -> FastAPI:
 
         import boto3
 
+        from cogos.db.models import ProcessStatus, Run, RunStatus
         from cogos.db.models.channel_message import ChannelMessage
         from dashboard.db import get_repo
 
@@ -201,11 +202,22 @@ def create_app() -> FastAPI:
                 "body": body,
             },
         )
-        repo.append_channel_message(msg)
+        msg_id = repo.append_channel_message(msg)
 
         executor_fn = os.environ.get("EXECUTOR_FUNCTION_NAME", "")
         if not executor_fn:
             return JSONResponse(status_code=503, content={"detail": "executor function not configured"})
+
+        queued_delivery = None
+        deliveries = repo.list_deliveries(message_id=msg_id, handler_id=target_handler.id, limit=1)
+        if deliveries:
+            queued_delivery = deliveries[0]
+
+        repo.update_process_status(process.id, ProcessStatus.RUNNING)
+        run = Run(process=process.id, message=msg_id, status=RunStatus.RUNNING)
+        run_id = repo.create_run(run)
+        if queued_delivery is not None:
+            repo.mark_queued(queued_delivery.id, run_id)
 
         def _invoke_executor() -> dict:
             lambda_client = boto3.client("lambda")
@@ -215,6 +227,8 @@ def create_app() -> FastAPI:
                 Payload=json.dumps(
                     {
                         "process_id": str(process.id),
+                        "run_id": str(run_id),
+                        "message_id": str(msg_id),
                         "web_request_id": request_id,
                         "web_request": {
                             "method": request.method,
@@ -239,6 +253,12 @@ def create_app() -> FastAPI:
                 media_type=web_response.get("headers", {}).get("content-type", "application/json"),
             )
         except Exception:
+            repo.rollback_dispatch(
+                process.id,
+                run_id,
+                queued_delivery.id if queued_delivery is not None else None,
+                error="executor invoke failed",
+            )
             logger.exception("Executor invocation failed")
             return JSONResponse(status_code=502, content={"detail": "executor error"})
 

--- a/tests/dashboard/test_web_proxy.py
+++ b/tests/dashboard/test_web_proxy.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from cogos.db.models import (
+    Channel,
+    ChannelType,
+    Delivery,
+    DeliveryStatus,
+    Handler,
+    Process,
+    ProcessMode,
+    ProcessStatus,
+)
+from dashboard.app import create_app
+
+
+class _Payload:
+    def __init__(self, body: str) -> None:
+        self._body = body.encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class _LambdaClient:
+    def __init__(self) -> None:
+        self.payloads: list[dict] = []
+
+    def invoke(self, *, FunctionName: str, InvocationType: str, Payload: str):
+        self.payloads.append(json.loads(Payload))
+        return {
+            "Payload": _Payload(
+                json.dumps(
+                    {
+                        "web_response": {
+                            "status": 200,
+                            "headers": {"content-type": "application/json"},
+                            "body": json.dumps({"ok": True}),
+                        }
+                    }
+                )
+            )
+        }
+
+
+class _WebProxyRepoStub:
+    def __init__(self) -> None:
+        self.channel = Channel(id=uuid4(), name="io:web:request", channel_type=ChannelType.NAMED)
+        self.process = Process(
+            id=uuid4(),
+            name="web.handler",
+            mode=ProcessMode.DAEMON,
+            status=ProcessStatus.WAITING,
+            runner="lambda",
+        )
+        self.handler = Handler(id=uuid4(), process=self.process.id, channel=self.channel.id, enabled=True)
+        self.message_id = uuid4()
+        self.delivery = Delivery(
+            id=uuid4(),
+            message=self.message_id,
+            handler=self.handler.id,
+            status=DeliveryStatus.PENDING,
+        )
+        self.created_runs = []
+        self.queued = []
+        self.status_updates = []
+        self.rolled_back = None
+
+    def get_channel_by_name(self, name: str):
+        return self.channel if name == self.channel.name else None
+
+    def match_handlers_by_channel(self, channel_id):
+        return [self.handler] if channel_id == self.channel.id else []
+
+    def get_process(self, process_id):
+        return self.process if process_id == self.process.id else None
+
+    def append_channel_message(self, message):
+        self.last_message = message
+        return self.message_id
+
+    def list_deliveries(self, *, message_id=None, handler_id=None, run_id=None, limit: int = 500):
+        if message_id == self.message_id and handler_id == self.handler.id:
+            return [self.delivery]
+        return []
+
+    def update_process_status(self, process_id, status):
+        self.status_updates.append((process_id, status))
+
+    def create_run(self, run):
+        self.created_runs.append(run)
+        return run.id
+
+    def mark_queued(self, delivery_id, run_id):
+        self.queued.append((delivery_id, run_id))
+        return True
+
+    def rollback_dispatch(self, process_id, run_id, delivery_id=None, *, error=None):
+        self.rolled_back = (process_id, run_id, delivery_id, error)
+
+
+def test_web_proxy_queues_linked_run_and_passes_message_id(monkeypatch):
+    app = create_app()
+    client = TestClient(app)
+    repo = _WebProxyRepoStub()
+    lambda_client = _LambdaClient()
+
+    monkeypatch.setenv("EXECUTOR_FUNCTION_NAME", "test-executor")
+
+    with patch("dashboard.db.get_repo", return_value=repo), patch("boto3.client", return_value=lambda_client):
+        response = client.get("/web/api/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    assert len(repo.created_runs) == 1
+    created_run = repo.created_runs[0]
+    assert created_run.message == repo.message_id
+
+    assert repo.queued == [(repo.delivery.id, created_run.id)]
+    assert repo.rolled_back is None
+
+    assert len(lambda_client.payloads) == 1
+    payload = lambda_client.payloads[0]
+    assert payload["process_id"] == str(repo.process.id)
+    assert payload["message_id"] == str(repo.message_id)
+    assert payload["run_id"] == str(created_run.id)
+    assert payload["web_request"]["path"] == "status"


### PR DESCRIPTION
Problem

Proxied `/web/api/*` requests were emitted as channel messages, but the dashboard path had no explicit run or queued-delivery linkage before invoking the executor. That left request-linked traces without a stable `message_id`/`run_id` bridge to the actual process execution, which made end-to-end request flow reconstruction brittle.

Summary

- create the queued run and mark the matched delivery before invoking the executor for proxied web requests
- pass the linked `message_id` and `run_id` into the executor payload alongside the existing web request metadata
- roll back the dispatch bookkeeping if the executor invoke fails
- add focused coverage for the web proxy dispatch path

Testing

- `uv run pytest tests/dashboard/test_web_proxy.py`