### PR TITLE
Add request flow API and dashboard tab

### DIFF
--- a/dashboard/frontend/src/app/page.tsx
+++ b/dashboard/frontend/src/app/page.tsx
@@ -11,6 +11,7 @@ import { CapabilitiesPanel } from "@/components/capabilities/CapabilitiesPanel";
 import { HandlersPanel } from "@/components/handlers/HandlersPanel";
 import { RunsPanel } from "@/components/runs/RunsPanel";
 import { TracePanel } from "@/components/traces/TracePanel";
+import { RequestFlowsPanel } from "@/components/requests/RequestFlowsPanel";
 import { ResourcesPanel } from "@/components/resources/ResourcesPanel";
 import { AlertsPanel } from "@/components/alerts/AlertsPanel";
 import { CronPanel } from "@/components/cron/CronPanel";
@@ -56,6 +57,12 @@ export default function DashboardPage() {
 
 function Dashboard({ cogentName, activeTab, onTabChange }: { cogentName: string; activeTab: TabId; onTabChange: (tab: TabId) => void }) {
   const { data, loading, error, refresh, timeRange, setTimeRange, connected } = useCogentData(cogentName);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshNonce((value) => value + 1);
+    await refresh();
+  }, [refresh]);
 
   const STUCK_THRESHOLD_MS = 10 * 60 * 1000;
   const stuckProcessCount = useMemo(() => {
@@ -89,7 +96,7 @@ function Dashboard({ cogentName, activeTab, onTabChange }: { cogentName: string;
         statusText={statusText}
         timeRange={timeRange}
         onTimeRangeChange={setTimeRange}
-        onRefresh={refresh}
+        onRefresh={handleRefresh}
         loading={loading}
         error={error}
         wsConnected={connected}
@@ -132,6 +139,9 @@ function Dashboard({ cogentName, activeTab, onTabChange }: { cogentName: string;
         )}
         {activeTab === "trace" && (
           <TracePanel traces={data.traces} cogentName={cogentName} timeRange={timeRange} onRefresh={refresh} />
+        )}
+        {activeTab === "requests" && (
+          <RequestFlowsPanel cogentName={cogentName} timeRange={timeRange} refreshNonce={refreshNonce} />
         )}
         {activeTab === "cron" && (
           <CronPanel crons={data.crons} cogentName={cogentName} onRefresh={refresh} />

--- a/dashboard/frontend/src/components/Sidebar.tsx
+++ b/dashboard/frontend/src/components/Sidebar.tsx
@@ -73,6 +73,18 @@ const TABS = [
     ),
   },
   {
+    id: "requests",
+    label: "Requests",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 6h16" />
+        <path d="M4 12h10" />
+        <path d="M4 18h8" />
+        <path d="M17 9l3 3-3 3" />
+      </svg>
+    ),
+  },
+  {
     id: "cron",
     label: "Cron",
     icon: (

--- a/dashboard/frontend/src/components/requests/RequestFlowsPanel.tsx
+++ b/dashboard/frontend/src/components/requests/RequestFlowsPanel.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Badge } from "@/components/shared/Badge";
+import { JsonViewer } from "@/components/shared/JsonViewer";
+import { fmtCost, fmtMs, fmtNum, fmtTimestamp } from "@/lib/format";
+import type {
+  RequestFlow,
+  RequestFlowEdge,
+  RequestFlowNode,
+  TimeRange,
+} from "@/lib/types";
+import * as api from "@/lib/api";
+
+interface RequestFlowsPanelProps {
+  cogentName: string;
+  timeRange: TimeRange;
+  refreshNonce: number;
+}
+
+type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral" | "accent";
+
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+  completed: "success",
+  delivered: "success",
+  running: "accent",
+  received: "info",
+  queued: "info",
+  pending: "warning",
+  orphaned: "warning",
+  failed: "error",
+  timeout: "error",
+};
+
+const ALL_STATUS = "__all__";
+
+function shortId(value: string | null | undefined): string {
+  if (!value) return "--";
+  return value.length > 12 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+}
+
+function statusVariant(status: string | null | undefined): BadgeVariant {
+  return STATUS_VARIANT[status ?? ""] ?? "neutral";
+}
+
+function flowSearchBlob(flow: RequestFlow): string {
+  const parts = [
+    flow.request_id,
+    flow.status,
+    flow.method ?? "",
+    flow.path ?? "",
+    flow.root_message.channel_name,
+    flow.root_message.message_type ?? "",
+    JSON.stringify(flow.root_message.payload),
+  ];
+
+  for (const node of flow.nodes) {
+    parts.push(
+      node.label,
+      node.status,
+      node.process_name ?? "",
+      node.process_id ?? "",
+      node.run_id ?? "",
+      node.channel_name ?? "",
+      node.message_type ?? "",
+      node.error ?? "",
+    );
+  }
+
+  for (const edge of flow.edges) {
+    parts.push(
+      edge.channel_name,
+      edge.message_type ?? "",
+      edge.handler_id ?? "",
+      edge.message_id,
+      edge.status ?? "",
+    );
+  }
+
+  return parts.join(" ").toLowerCase();
+}
+
+function FlowNodeCard({ flow, node }: { flow: RequestFlow; node: RequestFlowNode }) {
+  if (node.kind === "request") {
+    return (
+      <div
+        className="rounded-xl border p-4"
+        style={{
+          background: "linear-gradient(135deg, rgba(37,99,235,0.12), rgba(15,23,42,0.5))",
+          borderColor: "rgba(59,130,246,0.25)",
+        }}
+      >
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+          <Badge variant="info">Request</Badge>
+          <Badge variant={statusVariant(flow.status)}>{flow.status}</Badge>
+          <span>{fmtTimestamp(flow.started_at)}</span>
+        </div>
+        <div className="mt-2 text-[15px] font-semibold text-[var(--text-primary)]">
+          {flow.method ?? "REQUEST"} {flow.path ?? flow.request_id}
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-[var(--text-secondary)]">
+          <span>request_id {flow.request_id}</span>
+          <span>{flow.root_message.channel_name}</span>
+          {flow.root_message.message_type && <span>{flow.root_message.message_type}</span>}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-xl border p-4"
+      style={{
+        background: "var(--bg-elevated)",
+        borderColor: "var(--border)",
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+        <Badge variant={statusVariant(node.status)}>{node.status}</Badge>
+        {node.runner && <Badge variant="neutral">{node.runner}</Badge>}
+        <span>run {shortId(node.run_id)}</span>
+      </div>
+      <div className="mt-2 text-[14px] font-semibold text-[var(--text-primary)]">
+        {node.process_name ?? node.label}
+      </div>
+      <div className="mt-2 grid gap-1 text-[12px] text-[var(--text-secondary)] md:grid-cols-2">
+        <span>started {fmtTimestamp(node.created_at)}</span>
+        <span>finished {fmtTimestamp(node.completed_at)}</span>
+        <span>duration {fmtMs(node.duration_ms)}</span>
+        <span>tokens {fmtNum(node.tokens_in)} in / {fmtNum(node.tokens_out)} out</span>
+        <span>cost {fmtCost(node.cost_usd)}</span>
+        {node.handler_id && <span>handler {shortId(node.handler_id)}</span>}
+      </div>
+      {node.error && (
+        <div
+          className="mt-3 rounded-lg border px-3 py-2 text-[12px]"
+          style={{
+            background: "rgba(239,68,68,0.08)",
+            borderColor: "rgba(239,68,68,0.18)",
+            color: "var(--text-secondary)",
+          }}
+        >
+          {node.error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EdgeCard({ edge }: { edge: RequestFlowEdge }) {
+  return (
+    <div
+      className="rounded-lg border px-3 py-3 text-[12px]"
+      style={{
+        background: "var(--bg-base)",
+        borderColor: "var(--border)",
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+        <Badge variant="accent">{edge.channel_name}</Badge>
+        {edge.message_type && <Badge variant="neutral">{edge.message_type}</Badge>}
+        {edge.status && <Badge variant={statusVariant(edge.status)}>{edge.status}</Badge>}
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-3 text-[12px] text-[var(--text-secondary)]">
+        <span>message {shortId(edge.message_id)}</span>
+        <span>handler {shortId(edge.handler_id)}</span>
+        <span>emitted {fmtTimestamp(edge.created_at)}</span>
+        <span>matched {fmtTimestamp(edge.delivered_at)}</span>
+      </div>
+    </div>
+  );
+}
+
+function FlowBranch({
+  flow,
+  nodeId,
+  nodesById,
+  childrenBySource,
+  seen,
+}: {
+  flow: RequestFlow;
+  nodeId: string;
+  nodesById: Map<string, RequestFlowNode>;
+  childrenBySource: Map<string, RequestFlowEdge[]>;
+  seen: Set<string>;
+}) {
+  const node = nodesById.get(nodeId);
+  if (!node) return null;
+
+  const childEdges = childrenBySource.get(nodeId) ?? [];
+
+  return (
+    <div className="space-y-3">
+      <FlowNodeCard flow={flow} node={node} />
+      {childEdges.length > 0 && (
+        <div className="ml-5 space-y-4 border-l pl-4" style={{ borderColor: "var(--border)" }}>
+          {childEdges.map((edge) => {
+            const target = nodesById.get(edge.target);
+            const nextSeen = new Set(seen);
+            nextSeen.add(nodeId);
+
+            return (
+              <div key={edge.id} className="space-y-2">
+                <EdgeCard edge={edge} />
+                {target && !seen.has(edge.target) ? (
+                  <FlowBranch
+                    flow={flow}
+                    nodeId={edge.target}
+                    nodesById={nodesById}
+                    childrenBySource={childrenBySource}
+                    seen={nextSeen}
+                  />
+                ) : target ? (
+                  <div className="rounded-lg border px-3 py-2 text-[12px] text-[var(--text-muted)]" style={{ borderColor: "var(--border)" }}>
+                    Cycle elided at {target.process_name ?? target.label}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function RequestFlowsPanel({ cogentName, timeRange, refreshNonce }: RequestFlowsPanelProps) {
+  const [flows, setFlows] = useState<RequestFlow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState(ALL_STATUS);
+  const [expandedRequestIds, setExpandedRequestIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const loadFlows = async (background = false) => {
+      if (!background) {
+        setLoading(true);
+      }
+      try {
+        const nextFlows = await api.getRequestFlows(cogentName, timeRange, 30);
+        if (cancelled) return;
+        setFlows(nextFlows);
+        setError(null);
+        setExpandedRequestIds((current) => {
+          if (current.size > 0) return current;
+          return nextFlows.length > 0 ? new Set([nextFlows[0].request_id]) : new Set();
+        });
+      } catch (loadError) {
+        if (cancelled) return;
+        setError(loadError instanceof Error ? loadError.message : "Could not load request flows.");
+      } finally {
+        if (!cancelled && !background) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadFlows();
+    intervalId = setInterval(() => {
+      void loadFlows(true);
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
+  }, [cogentName, refreshNonce, timeRange]);
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const visibleFlows = flows.filter((flow) => {
+    if (statusFilter !== ALL_STATUS && flow.status !== statusFilter) {
+      return false;
+    }
+    if (!normalizedQuery) {
+      return true;
+    }
+    return flowSearchBlob(flow).includes(normalizedQuery);
+  });
+
+  const summary = visibleFlows.reduce(
+    (acc, flow) => {
+      acc.total += 1;
+      if (flow.status === "completed") acc.completed += 1;
+      if (flow.status === "running") acc.running += 1;
+      if (flow.status === "failed") acc.failed += 1;
+      if (flow.status === "orphaned") acc.orphaned += 1;
+      return acc;
+    },
+    { total: 0, completed: 0, running: 0, failed: 0, orphaned: 0 },
+  );
+
+  return (
+    <div className="space-y-5">
+      <section
+        className="rounded-2xl border p-5"
+        style={{
+          background: "linear-gradient(135deg, rgba(15,23,42,0.96), rgba(20,30,48,0.82))",
+          borderColor: "var(--border)",
+        }}
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--text-muted)]">
+              Request Flows
+            </div>
+            <div className="max-w-3xl text-[14px] text-[var(--text-secondary)]">
+              Follow each `request_id` from the incoming request message through handler matches, process runs,
+              downstream channel hops, and terminal completion.
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-[12px] text-[var(--text-secondary)]">
+            <Badge variant="info">{summary.total} visible</Badge>
+            <Badge variant="success">{summary.completed} completed</Badge>
+            <Badge variant="accent">{summary.running} running</Badge>
+            <Badge variant="error">{summary.failed} failed</Badge>
+            {summary.orphaned > 0 && <Badge variant="warning">{summary.orphaned} orphaned</Badge>}
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_180px]">
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search request_id, path, process, channel, or message type"
+            className="rounded-xl border px-4 py-3 text-[14px] outline-none transition-colors"
+            style={{
+              background: "var(--bg-base)",
+              borderColor: "var(--border)",
+              color: "var(--text-primary)",
+            }}
+          />
+          <select
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value)}
+            className="rounded-xl border px-4 py-3 text-[14px] outline-none transition-colors"
+            style={{
+              background: "var(--bg-base)",
+              borderColor: "var(--border)",
+              color: "var(--text-primary)",
+            }}
+          >
+            <option value={ALL_STATUS}>All statuses</option>
+            <option value="completed">Completed</option>
+            <option value="running">Running</option>
+            <option value="failed">Failed</option>
+            <option value="orphaned">Orphaned</option>
+          </select>
+        </div>
+      </section>
+
+      {loading && (
+        <div className="rounded-xl border px-4 py-6 text-[13px] text-[var(--text-muted)]" style={{ borderColor: "var(--border)" }}>
+          Loading request flows...
+        </div>
+      )}
+
+      {!loading && error && (
+        <div
+          className="rounded-xl border px-4 py-6 text-[13px]"
+          style={{
+            background: "rgba(239,68,68,0.08)",
+            borderColor: "rgba(239,68,68,0.18)",
+            color: "var(--text-secondary)",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && visibleFlows.length === 0 && (
+        <div className="rounded-xl border px-4 py-6 text-[13px] text-[var(--text-muted)]" style={{ borderColor: "var(--border)" }}>
+          No request flows matched the current filters.
+        </div>
+      )}
+
+      {!loading && !error && visibleFlows.map((flow) => {
+        const expanded = expandedRequestIds.has(flow.request_id);
+        const nodesById = new Map(flow.nodes.map((node) => [node.id, node]));
+        const childrenBySource = new Map<string, RequestFlowEdge[]>();
+        for (const edge of flow.edges) {
+          const current = childrenBySource.get(edge.source) ?? [];
+          current.push(edge);
+          current.sort((left, right) => (left.created_at ?? "").localeCompare(right.created_at ?? ""));
+          childrenBySource.set(edge.source, current);
+        }
+
+        return (
+          <section
+            key={flow.request_id}
+            className="overflow-hidden rounded-2xl border"
+            style={{
+              background: "var(--bg-elevated)",
+              borderColor: "var(--border)",
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setExpandedRequestIds((current) => {
+                const next = new Set(current);
+                if (next.has(flow.request_id)) {
+                  next.delete(flow.request_id);
+                } else {
+                  next.add(flow.request_id);
+                }
+                return next;
+              })}
+              className="w-full px-5 py-4 text-left"
+            >
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="info">{flow.request_id}</Badge>
+                    <Badge variant={statusVariant(flow.status)}>{flow.status}</Badge>
+                    {flow.method && <Badge variant="neutral">{flow.method}</Badge>}
+                  </div>
+                  <div className="text-[15px] font-semibold text-[var(--text-primary)]">
+                    {flow.path ?? flow.root_message.channel_name}
+                  </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-4 text-[12px] text-[var(--text-secondary)]">
+                  <span>started {fmtTimestamp(flow.started_at)}</span>
+                  <span>duration {fmtMs(flow.duration_ms)}</span>
+                  <span>{flow.total_runs} runs</span>
+                  <span>{flow.total_edges} bridges</span>
+                  <span>{flow.total_messages} messages</span>
+                </div>
+              </div>
+            </button>
+
+            {expanded && (
+              <div className="border-t px-5 py-5" style={{ borderColor: "var(--border)" }}>
+                <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(360px,0.9fr)]">
+                  <div className="space-y-5">
+                    <div className="space-y-2">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                        Process Graph
+                      </div>
+                      <FlowBranch
+                        flow={flow}
+                        nodeId={`request:${flow.request_id}`}
+                        nodesById={nodesById}
+                        childrenBySource={childrenBySource}
+                        seen={new Set()}
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                        Root Payload
+                      </div>
+                      <JsonViewer data={flow.root_message.payload} />
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                      Timeline
+                    </div>
+                    <div className="space-y-2">
+                      {flow.timeline.map((entry) => (
+                        <div
+                          key={entry.id}
+                          className="rounded-xl border px-4 py-3"
+                          style={{
+                            background: "var(--bg-base)",
+                            borderColor: "var(--border)",
+                          }}
+                        >
+                          <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+                            <Badge variant={statusVariant(entry.status ?? entry.kind)}>{entry.kind.replaceAll("_", " ")}</Badge>
+                            {entry.status && <Badge variant={statusVariant(entry.status)}>{entry.status}</Badge>}
+                            <span>{fmtTimestamp(entry.timestamp)}</span>
+                          </div>
+                          <div className="mt-2 text-[13px] font-medium text-[var(--text-primary)]">
+                            {entry.title}
+                          </div>
+                          {entry.detail && (
+                            <div className="mt-1 text-[12px] text-[var(--text-secondary)]">
+                              {entry.detail}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   Alert,
   SetupResponse,
   MessageTrace,
+  RequestFlow,
   CogosChannel,
   ChannelSendResult,
   ProcessLogsResponse,
@@ -77,6 +78,18 @@ export async function getMessageTraces(
     `/api/cogents/${name}/message-traces?${params.toString()}`,
   );
   return r.traces;
+}
+
+export async function getRequestFlows(
+  name: string,
+  range: TimeRange = "1h",
+  limit: number = 30,
+): Promise<RequestFlow[]> {
+  const params = new URLSearchParams({ range, limit: String(limit) });
+  const r = await fetchJSON<{ flows: RequestFlow[] }>(
+    `/api/cogents/${name}/request-flows?${params.toString()}`,
+  );
+  return r.flows;
 }
 
 export async function getChannels(

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -269,6 +269,82 @@ export interface MessageTrace {
   deliveries: TraceDelivery[];
 }
 
+export interface RequestFlowMessage {
+  id: string;
+  channel_id: string;
+  channel_name: string;
+  message_type: string | null;
+  sender_process: string | null;
+  sender_process_name: string | null;
+  payload: Record<string, unknown>;
+  created_at: string | null;
+}
+
+export interface RequestFlowNode {
+  id: string;
+  kind: "request" | "process";
+  label: string;
+  depth: number;
+  status: string;
+  process_id: string | null;
+  process_name: string | null;
+  run_id: string | null;
+  runner: string | null;
+  handler_id: string | null;
+  created_at: string | null;
+  completed_at: string | null;
+  duration_ms: number | null;
+  tokens_in: number | null;
+  tokens_out: number | null;
+  cost_usd: number | null;
+  error: string | null;
+  channel_name: string | null;
+  message_type: string | null;
+}
+
+export interface RequestFlowEdge {
+  id: string;
+  source: string;
+  target: string;
+  message_id: string;
+  delivery_id: string | null;
+  handler_id: string | null;
+  channel_id: string;
+  channel_name: string;
+  message_type: string | null;
+  status: string | null;
+  created_at: string | null;
+  delivered_at: string | null;
+}
+
+export interface RequestFlowTimelineEntry {
+  id: string;
+  kind: "request_received" | "handler_matched" | "run_started" | "run_completed" | "message_emitted";
+  timestamp: string | null;
+  title: string;
+  detail: string | null;
+  status: string | null;
+  node_id: string | null;
+  edge_id: string | null;
+}
+
+export interface RequestFlow {
+  request_id: string;
+  status: string;
+  started_at: string | null;
+  completed_at: string | null;
+  duration_ms: number | null;
+  method: string | null;
+  path: string | null;
+  total_runs: number;
+  total_edges: number;
+  total_messages: number;
+  root_message: RequestFlowMessage;
+  nodes: RequestFlowNode[];
+  edges: RequestFlowEdge[];
+  timeline: RequestFlowTimelineEntry[];
+}
+
 export interface Trigger {
   id: string;
   name: string;

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -72,6 +72,7 @@ def create_app() -> FastAPI:
         files,
         handlers,
         processes,
+        request_flows,
         resources,
         runs,
         schemas,
@@ -88,6 +89,7 @@ def create_app() -> FastAPI:
     app.include_router(schemas.router, prefix="/api/cogents/{name}")
     app.include_router(runs.router, prefix="/api/cogents/{name}")
     app.include_router(traces.router, prefix="/api/cogents/{name}")
+    app.include_router(request_flows.router, prefix="/api/cogents/{name}")
     app.include_router(cogos_status.router, prefix="/api/cogents/{name}")
     app.include_router(cron.router, prefix="/api/cogents/{name}")
     app.include_router(resources.router, prefix="/api/cogents/{name}")

--- a/src/dashboard/routers/request_flows.py
+++ b/src/dashboard/routers/request_flows.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from cogos.db.models import ChannelMessage, Delivery, Run
+from dashboard.db import get_repo
+
+router = APIRouter(tags=["request-flows"])
+
+RequestRange = Literal["1m", "10m", "1h", "24h", "1w"]
+
+_RANGE_TO_DELTA: dict[RequestRange, timedelta] = {
+    "1m": timedelta(minutes=1),
+    "10m": timedelta(minutes=10),
+    "1h": timedelta(hours=1),
+    "24h": timedelta(hours=24),
+    "1w": timedelta(weeks=1),
+}
+
+_MAX_FLOW_DEPTH = 12
+
+
+class RequestMessageOut(BaseModel):
+    id: str
+    channel_id: str
+    channel_name: str
+    message_type: str | None = None
+    sender_process: str | None = None
+    sender_process_name: str | None = None
+    payload: dict[str, Any]
+    created_at: str | None = None
+
+
+class RequestFlowNodeOut(BaseModel):
+    id: str
+    kind: Literal["request", "process"]
+    label: str
+    depth: int
+    status: str
+    process_id: str | None = None
+    process_name: str | None = None
+    run_id: str | None = None
+    runner: str | None = None
+    handler_id: str | None = None
+    created_at: str | None = None
+    completed_at: str | None = None
+    duration_ms: int | None = None
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    cost_usd: float | None = None
+    error: str | None = None
+    channel_name: str | None = None
+    message_type: str | None = None
+
+
+class RequestFlowEdgeOut(BaseModel):
+    id: str
+    source: str
+    target: str
+    message_id: str
+    delivery_id: str | None = None
+    handler_id: str | None = None
+    channel_id: str
+    channel_name: str
+    message_type: str | None = None
+    status: str | None = None
+    created_at: str | None = None
+    delivered_at: str | None = None
+
+
+class RequestFlowTimelineEntryOut(BaseModel):
+    id: str
+    kind: Literal["request_received", "handler_matched", "run_started", "run_completed", "message_emitted"]
+    timestamp: str | None = None
+    title: str
+    detail: str | None = None
+    status: str | None = None
+    node_id: str | None = None
+    edge_id: str | None = None
+
+
+class RequestFlowOut(BaseModel):
+    request_id: str
+    status: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    duration_ms: int | None = None
+    method: str | None = None
+    path: str | None = None
+    total_runs: int
+    total_edges: int
+    total_messages: int
+    root_message: RequestMessageOut
+    nodes: list[RequestFlowNodeOut]
+    edges: list[RequestFlowEdgeOut]
+    timeline: list[RequestFlowTimelineEntryOut]
+
+
+class RequestFlowsResponse(BaseModel):
+    count: int
+    flows: list[RequestFlowOut]
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _iso(dt: datetime | None) -> str | None:
+    normalized = _as_utc(dt)
+    return normalized.isoformat() if normalized else None
+
+
+def _message_sort_key(message: ChannelMessage) -> datetime:
+    return _as_utc(message.created_at) or datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _message_type(message: ChannelMessage) -> str | None:
+    payload = message.payload or {}
+    for key in ("message_type", "type"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def _request_id(message: ChannelMessage) -> str | None:
+    payload = message.payload or {}
+    for key in ("request_id", "requestId"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def _message_out(
+    message: ChannelMessage,
+    *,
+    channel_names: dict[UUID, str],
+    process_names: dict[UUID, str],
+) -> RequestMessageOut:
+    return RequestMessageOut(
+        id=str(message.id),
+        channel_id=str(message.channel),
+        channel_name=channel_names.get(message.channel, str(message.channel)),
+        message_type=_message_type(message),
+        sender_process=str(message.sender_process) if message.sender_process else None,
+        sender_process_name=process_names.get(message.sender_process) if message.sender_process else None,
+        payload=message.payload or {},
+        created_at=_iso(message.created_at),
+    )
+
+
+def _emitted_messages_for_run(
+    run: Run,
+    source_message_id: UUID,
+    all_messages: list[ChannelMessage],
+) -> list[ChannelMessage]:
+    if run.created_at is None:
+        return []
+
+    start = _as_utc(run.created_at)
+    completed = _as_utc(run.completed_at)
+    end = completed + timedelta(seconds=5) if completed else None
+
+    emitted = []
+    for message in all_messages:
+        if message.id == source_message_id:
+            continue
+        if message.sender_process != run.process:
+            continue
+
+        created_at = _as_utc(message.created_at)
+        if created_at is None or created_at < start:
+            continue
+        if end is not None and created_at > end:
+            continue
+
+        emitted.append(message)
+
+    emitted.sort(key=_message_sort_key)
+    return emitted
+
+
+def _timeline_timestamp_sort_key(timestamp: str | None) -> tuple[int, str]:
+    return (0 if timestamp else 1, timestamp or "")
+
+
+def _node_sort_key(node: RequestFlowNodeOut) -> tuple[int, str, str]:
+    return (node.depth, node.created_at or "", node.id)
+
+
+def _edge_sort_key(edge: RequestFlowEdgeOut) -> tuple[str, str]:
+    return (edge.created_at or edge.delivered_at or "", edge.id)
+
+
+def _find_run_for_delivery(
+    delivery: Delivery,
+    *,
+    target_process_id: UUID,
+    runs_by_id: dict[UUID, Run],
+    runs_by_message_process: dict[tuple[UUID, UUID], list[Run]],
+) -> Run | None:
+    if delivery.run is not None:
+        return runs_by_id.get(delivery.run)
+
+    candidates = runs_by_message_process.get((delivery.message, target_process_id), [])
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _flow_status(nodes: list[RequestFlowNodeOut]) -> str:
+    process_nodes = [node for node in nodes if node.kind == "process"]
+    statuses = {node.status for node in process_nodes}
+    if not process_nodes:
+        return "orphaned"
+    if "failed" in statuses or "timeout" in statuses:
+        return "failed"
+    if "running" in statuses or "pending" in statuses or "queued" in statuses:
+        return "running"
+    return "completed"
+
+
+def _latest_activity(timeline: list[RequestFlowTimelineEntryOut]) -> datetime | None:
+    timestamps = [datetime.fromisoformat(entry.timestamp) for entry in timeline if entry.timestamp]
+    return max(timestamps) if timestamps else None
+
+
+@router.get("/request-flows", response_model=RequestFlowsResponse)
+def list_request_flows(
+    name: str,
+    range: RequestRange = Query("1h"),
+    limit: int = Query(30, ge=1, le=100),
+) -> RequestFlowsResponse:
+    repo = get_repo()
+    cutoff = datetime.now(timezone.utc) - _RANGE_TO_DELTA[range]
+    fetch_limit = max(limit * 50, 1500)
+
+    processes = repo.list_processes(limit=1000)
+    channels = repo.list_channels()
+    handlers = repo.list_handlers()
+    messages = repo.list_channel_messages(limit=fetch_limit)
+    deliveries = repo.list_deliveries(limit=max(fetch_limit * 2, 2000))
+    runs = repo.list_runs(limit=max(fetch_limit * 2, 2000))
+
+    process_names = {process.id: process.name for process in processes}
+    process_runners = {process.id: process.runner for process in processes}
+    channel_names = {channel.id: channel.name for channel in channels}
+    handlers_by_id = {handler.id: handler for handler in handlers}
+    runs_by_id = {run.id: run for run in runs}
+
+    deliveries_by_message: dict[UUID, list[Delivery]] = {}
+    for delivery in deliveries:
+        deliveries_by_message.setdefault(delivery.message, []).append(delivery)
+
+    runs_by_message_process: dict[tuple[UUID, UUID], list[Run]] = {}
+    for run in runs:
+        if run.message is None:
+            continue
+        runs_by_message_process.setdefault((run.message, run.process), []).append(run)
+    for candidates in runs_by_message_process.values():
+        candidates.sort(key=lambda run: _as_utc(run.created_at) or datetime.min.replace(tzinfo=timezone.utc))
+
+    request_messages: dict[str, list[ChannelMessage]] = {}
+    for message in messages:
+        created_at = _as_utc(message.created_at)
+        if created_at is not None and created_at < cutoff:
+            continue
+        request_id = _request_id(message)
+        if request_id is None:
+            continue
+        request_messages.setdefault(request_id, []).append(message)
+
+    root_candidates: list[tuple[str, ChannelMessage]] = []
+    for request_id, grouped_messages in request_messages.items():
+        grouped_messages.sort(key=_message_sort_key)
+        root_message = next((message for message in grouped_messages if message.sender_process is None), grouped_messages[0])
+        root_candidates.append((request_id, root_message))
+
+    root_candidates.sort(key=lambda item: _message_sort_key(item[1]), reverse=True)
+
+    flows: list[RequestFlowOut] = []
+    for request_id, root_message in root_candidates[:limit]:
+        method = root_message.payload.get("method") if isinstance(root_message.payload.get("method"), str) else None
+        path = root_message.payload.get("path") if isinstance(root_message.payload.get("path"), str) else None
+
+        request_node_id = f"request:{request_id}"
+        request_node = RequestFlowNodeOut(
+            id=request_node_id,
+            kind="request",
+            label=f"{method or 'REQUEST'} {path or request_id}".strip(),
+            depth=0,
+            status="received",
+            created_at=_iso(root_message.created_at),
+            channel_name=channel_names.get(root_message.channel, str(root_message.channel)),
+            message_type=_message_type(root_message),
+        )
+
+        nodes: dict[str, RequestFlowNodeOut] = {request_node_id: request_node}
+        edges: dict[str, RequestFlowEdgeOut] = {}
+        timeline: dict[str, RequestFlowTimelineEntryOut] = {
+            f"request:{root_message.id}": RequestFlowTimelineEntryOut(
+                id=f"request:{root_message.id}",
+                kind="request_received",
+                timestamp=_iso(root_message.created_at),
+                title=f"Request received on {channel_names.get(root_message.channel, str(root_message.channel))}",
+                detail=f"request_id={request_id}",
+                status="received",
+                node_id=request_node_id,
+            )
+        }
+        flow_message_ids: set[UUID] = {root_message.id}
+        visited_runs: set[UUID] = set()
+
+        def upsert_process_node(
+            *,
+            delivery: Delivery,
+            depth: int,
+            run: Run | None,
+            process_id: UUID,
+        ) -> str:
+            if run is not None:
+                node_id = f"run:{run.id}"
+                existing = nodes.get(node_id)
+                if existing is None:
+                    nodes[node_id] = RequestFlowNodeOut(
+                        id=node_id,
+                        kind="process",
+                        label=process_names.get(process_id, str(process_id)),
+                        depth=depth,
+                        status=run.status.value,
+                        process_id=str(process_id),
+                        process_name=process_names.get(process_id),
+                        run_id=str(run.id),
+                        runner=process_runners.get(process_id),
+                        created_at=_iso(run.created_at),
+                        completed_at=_iso(run.completed_at),
+                        duration_ms=run.duration_ms,
+                        tokens_in=run.tokens_in,
+                        tokens_out=run.tokens_out,
+                        cost_usd=float(run.cost_usd),
+                        error=run.error,
+                    )
+                else:
+                    existing.depth = min(existing.depth, depth)
+                return node_id
+
+            node_id = f"pending:{delivery.id}"
+            existing = nodes.get(node_id)
+            if existing is None:
+                nodes[node_id] = RequestFlowNodeOut(
+                    id=node_id,
+                    kind="process",
+                    label=process_names.get(process_id, str(process_id)),
+                    depth=depth,
+                    status=delivery.status.value,
+                    process_id=str(process_id),
+                    process_name=process_names.get(process_id),
+                    handler_id=str(delivery.handler),
+                    created_at=_iso(delivery.created_at),
+                )
+            else:
+                existing.depth = min(existing.depth, depth)
+            return node_id
+
+        def walk_message(message: ChannelMessage, source_node_id: str, depth: int) -> None:
+            if depth > _MAX_FLOW_DEPTH:
+                return
+
+            flow_message_ids.add(message.id)
+            if source_node_id != request_node_id:
+                timeline.setdefault(
+                    f"message:{message.id}",
+                    RequestFlowTimelineEntryOut(
+                        id=f"message:{message.id}",
+                        kind="message_emitted",
+                        timestamp=_iso(message.created_at),
+                        title=f"Message emitted to {channel_names.get(message.channel, str(message.channel))}",
+                        detail=_message_type(message) or str(message.id),
+                        node_id=source_node_id,
+                    ),
+                )
+
+            message_deliveries = sorted(
+                deliveries_by_message.get(message.id, []),
+                key=lambda delivery: _as_utc(delivery.created_at) or datetime.min.replace(tzinfo=timezone.utc),
+            )
+            for delivery in message_deliveries:
+                handler = handlers_by_id.get(delivery.handler)
+                if handler is None:
+                    continue
+
+                run = _find_run_for_delivery(
+                    delivery,
+                    target_process_id=handler.process,
+                    runs_by_id=runs_by_id,
+                    runs_by_message_process=runs_by_message_process,
+                )
+                target_node_id = upsert_process_node(
+                    delivery=delivery,
+                    depth=depth,
+                    run=run,
+                    process_id=handler.process,
+                )
+
+                edge_id = f"delivery:{delivery.id}"
+                edges.setdefault(
+                    edge_id,
+                    RequestFlowEdgeOut(
+                        id=edge_id,
+                        source=source_node_id,
+                        target=target_node_id,
+                        message_id=str(message.id),
+                        delivery_id=str(delivery.id),
+                        handler_id=str(delivery.handler),
+                        channel_id=str(message.channel),
+                        channel_name=channel_names.get(message.channel, str(message.channel)),
+                        message_type=_message_type(message),
+                        status=delivery.status.value,
+                        created_at=_iso(message.created_at),
+                        delivered_at=_iso(delivery.created_at),
+                    ),
+                )
+
+                timeline.setdefault(
+                    f"delivery:{delivery.id}",
+                    RequestFlowTimelineEntryOut(
+                        id=f"delivery:{delivery.id}",
+                        kind="handler_matched",
+                        timestamp=_iso(delivery.created_at),
+                        title=f"Handler matched for {process_names.get(handler.process, str(handler.process))}",
+                        detail=channel_names.get(message.channel, str(message.channel)),
+                        status=delivery.status.value,
+                        node_id=target_node_id,
+                        edge_id=edge_id,
+                    ),
+                )
+
+                if run is None:
+                    continue
+
+                timeline.setdefault(
+                    f"run-start:{run.id}",
+                    RequestFlowTimelineEntryOut(
+                        id=f"run-start:{run.id}",
+                        kind="run_started",
+                        timestamp=_iso(run.created_at),
+                        title=f"Run started: {process_names.get(run.process, str(run.process))}",
+                        detail=str(run.id),
+                        status=run.status.value,
+                        node_id=target_node_id,
+                        edge_id=edge_id,
+                    ),
+                )
+                if run.completed_at is not None:
+                    timeline.setdefault(
+                        f"run-end:{run.id}",
+                        RequestFlowTimelineEntryOut(
+                            id=f"run-end:{run.id}",
+                            kind="run_completed",
+                            timestamp=_iso(run.completed_at),
+                            title=f"Run finished: {process_names.get(run.process, str(run.process))}",
+                            detail=str(run.id),
+                            status=run.status.value,
+                            node_id=target_node_id,
+                            edge_id=edge_id,
+                        ),
+                    )
+
+                if run.id in visited_runs:
+                    continue
+                visited_runs.add(run.id)
+
+                for emitted_message in _emitted_messages_for_run(run, message.id, messages):
+                    walk_message(emitted_message, target_node_id, depth + 1)
+
+        walk_message(root_message, request_node_id, 1)
+
+        nodes_list = sorted(nodes.values(), key=_node_sort_key)
+        edges_list = sorted(edges.values(), key=_edge_sort_key)
+        timeline_list = sorted(timeline.values(), key=lambda entry: _timeline_timestamp_sort_key(entry.timestamp))
+        status = _flow_status(nodes_list)
+
+        started_at = _as_utc(root_message.created_at)
+        completed_at = _latest_activity(timeline_list)
+        end_for_duration = completed_at
+        if status == "running" and started_at is not None:
+            end_for_duration = datetime.now(timezone.utc)
+        if status == "orphaned" and started_at is not None:
+            end_for_duration = started_at
+
+        duration_ms = None
+        if started_at is not None and end_for_duration is not None:
+            duration_ms = max(0, int((end_for_duration - started_at).total_seconds() * 1000))
+
+        flows.append(
+            RequestFlowOut(
+                request_id=request_id,
+                status=status,
+                started_at=_iso(started_at),
+                completed_at=_iso(completed_at) if status != "running" else None,
+                duration_ms=duration_ms,
+                method=method,
+                path=path,
+                total_runs=len([node for node in nodes_list if node.run_id]),
+                total_edges=len(edges_list),
+                total_messages=len(flow_message_ids),
+                root_message=_message_out(
+                    root_message,
+                    channel_names=channel_names,
+                    process_names=process_names,
+                ),
+                nodes=nodes_list,
+                edges=edges_list,
+                timeline=timeline_list,
+            )
+        )
+
+    return RequestFlowsResponse(count=len(flows), flows=flows)

--- a/tests/dashboard/test_integration.py
+++ b/tests/dashboard/test_integration.py
@@ -24,6 +24,7 @@ def test_all_rest_endpoints_registered():
         ("GET", "/api/cogents/test/processes"),
         ("GET", "/api/cogents/test/runs"),
         ("GET", "/api/cogents/test/message-traces"),
+        ("GET", "/api/cogents/test/request-flows"),
         ("GET", "/api/cogents/test/channels"),
         ("POST", "/api/cogents/test/channels/00000000-0000-0000-0000-000000000000/messages"),
         ("GET", "/api/cogents/test/resources"),

--- a/tests/dashboard/test_routers_core.py
+++ b/tests/dashboard/test_routers_core.py
@@ -36,6 +36,11 @@ def test_message_traces_route_registered(client: TestClient):
     assert resp.status_code != 404
 
 
+def test_request_flows_route_registered(client: TestClient):
+    resp = client.get("/api/cogents/test-cogent/request-flows")
+    assert resp.status_code != 404
+
+
 def test_cogos_status_with_mock_repo():
     mock_repo = MagicMock()
     mock_repo.list_processes.return_value = []

--- a/tests/dashboard/test_routers_events.py
+++ b/tests/dashboard/test_routers_events.py
@@ -14,6 +14,12 @@ def test_trace_route_registered():
     assert "/api/cogents/{name}/message-traces" in paths
 
 
+def test_request_flow_route_registered():
+    app = create_app()
+    paths = _route_paths(app)
+    assert "/api/cogents/{name}/request-flows" in paths
+
+
 def test_channels_route_registered():
     app = create_app()
     paths = _route_paths(app)

--- a/tests/dashboard/test_routers_request_flows.py
+++ b/tests/dashboard/test_routers_request_flows.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from cogos.db.models import (
+    Channel,
+    ChannelMessage,
+    ChannelType,
+    Delivery,
+    DeliveryStatus,
+    Handler,
+    Process,
+    ProcessMode,
+    ProcessStatus,
+    Run,
+    RunStatus,
+)
+from dashboard.app import create_app
+
+
+class _RequestFlowRepoStub:
+    def __init__(self) -> None:
+        now = datetime.now(timezone.utc)
+        self.api_process = Process(
+            id=uuid4(),
+            name="api.router",
+            mode=ProcessMode.DAEMON,
+            status=ProcessStatus.WAITING,
+            runner="lambda",
+        )
+        self.worker_process = Process(
+            id=uuid4(),
+            name="tasks.worker",
+            mode=ProcessMode.DAEMON,
+            status=ProcessStatus.WAITING,
+            runner="python",
+        )
+
+        self.request_channel = Channel(
+            id=uuid4(),
+            name="io:web:request",
+            channel_type=ChannelType.NAMED,
+        )
+        self.worker_channel = Channel(
+            id=uuid4(),
+            name="tasks:fetch",
+            channel_type=ChannelType.NAMED,
+        )
+
+        self.root_message = ChannelMessage(
+            id=uuid4(),
+            channel=self.request_channel.id,
+            payload={
+                "request_id": "req-123",
+                "method": "GET",
+                "path": "/api/tasks",
+                "message_type": "web:request",
+            },
+            created_at=now,
+        )
+        self.handler_one = Handler(
+            id=uuid4(),
+            process=self.api_process.id,
+            channel=self.request_channel.id,
+            enabled=True,
+            created_at=now + timedelta(milliseconds=10),
+        )
+        self.run_one = Run(
+            id=uuid4(),
+            process=self.api_process.id,
+            message=self.root_message.id,
+            status=RunStatus.COMPLETED,
+            tokens_in=30,
+            tokens_out=15,
+            cost_usd=Decimal("0.01"),
+            duration_ms=900,
+            created_at=now + timedelta(milliseconds=100),
+            completed_at=now + timedelta(seconds=1),
+        )
+        self.delivery_one = Delivery(
+            id=uuid4(),
+            message=self.root_message.id,
+            handler=self.handler_one.id,
+            status=DeliveryStatus.DELIVERED,
+            run=self.run_one.id,
+            created_at=now + timedelta(milliseconds=30),
+        )
+
+        self.worker_message = ChannelMessage(
+            id=uuid4(),
+            channel=self.worker_channel.id,
+            sender_process=self.api_process.id,
+            payload={
+                "request_id": "req-123",
+                "message_type": "tasks:fetch",
+                "task_id": "task-42",
+            },
+            created_at=now + timedelta(milliseconds=500),
+        )
+        self.handler_two = Handler(
+            id=uuid4(),
+            process=self.worker_process.id,
+            channel=self.worker_channel.id,
+            enabled=True,
+            created_at=now + timedelta(milliseconds=550),
+        )
+        self.run_two = Run(
+            id=uuid4(),
+            process=self.worker_process.id,
+            message=self.worker_message.id,
+            status=RunStatus.COMPLETED,
+            tokens_in=12,
+            tokens_out=8,
+            cost_usd=Decimal("0.003"),
+            duration_ms=600,
+            created_at=now + timedelta(milliseconds=650),
+            completed_at=now + timedelta(seconds=2),
+        )
+        self.delivery_two = Delivery(
+            id=uuid4(),
+            message=self.worker_message.id,
+            handler=self.handler_two.id,
+            status=DeliveryStatus.DELIVERED,
+            run=self.run_two.id,
+            created_at=now + timedelta(milliseconds=600),
+        )
+
+    def list_processes(self, *, limit: int = 1000):
+        return [self.api_process, self.worker_process]
+
+    def list_channels(self):
+        return [self.request_channel, self.worker_channel]
+
+    def list_handlers(self):
+        return [self.handler_one, self.handler_two]
+
+    def list_channel_messages(self, channel_id=None, *, limit: int = 100):
+        messages = [self.worker_message, self.root_message]
+        if channel_id is not None:
+            messages = [message for message in messages if message.channel == channel_id]
+        return messages[:limit]
+
+    def list_deliveries(self, *, message_id=None, handler_id=None, run_id=None, limit: int = 500):
+        deliveries = [self.delivery_one, self.delivery_two]
+        if message_id is not None:
+            deliveries = [delivery for delivery in deliveries if delivery.message == message_id]
+        if handler_id is not None:
+            deliveries = [delivery for delivery in deliveries if delivery.handler == handler_id]
+        if run_id is not None:
+            deliveries = [delivery for delivery in deliveries if delivery.run == run_id]
+        return deliveries[:limit]
+
+    def list_runs(self, *, process_id=None, limit: int = 50):
+        runs = [self.run_two, self.run_one]
+        if process_id is not None:
+            runs = [run for run in runs if run.process == process_id]
+        return runs[:limit]
+
+
+def test_request_flows_endpoint_returns_recursive_request_graph():
+    app = create_app()
+    client = TestClient(app)
+    repo = _RequestFlowRepoStub()
+
+    with patch("dashboard.routers.request_flows.get_repo", return_value=repo):
+        response = client.get("/api/cogents/test/request-flows?range=1h")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+
+    flow = payload["flows"][0]
+    assert flow["request_id"] == "req-123"
+    assert flow["status"] == "completed"
+    assert flow["method"] == "GET"
+    assert flow["path"] == "/api/tasks"
+    assert flow["total_runs"] == 2
+    assert flow["total_edges"] == 2
+    assert flow["total_messages"] == 2
+    assert flow["root_message"]["id"] == str(repo.root_message.id)
+
+    node_kinds = {node["kind"] for node in flow["nodes"]}
+    assert node_kinds == {"request", "process"}
+    process_names = {node["process_name"] for node in flow["nodes"] if node["kind"] == "process"}
+    assert process_names == {"api.router", "tasks.worker"}
+
+    edge_channels = [edge["channel_name"] for edge in flow["edges"]]
+    assert edge_channels == ["io:web:request", "tasks:fetch"]
+
+    timeline_kinds = {entry["kind"] for entry in flow["timeline"]}
+    assert "request_received" in timeline_kinds
+    assert "handler_matched" in timeline_kinds
+    assert "run_started" in timeline_kinds
+    assert "run_completed" in timeline_kinds
+    assert "message_emitted" in timeline_kinds


### PR DESCRIPTION
Problem

The dashboard only exposed message-centric traces, so there was no operator view that followed a single `request_id` across handler matches, process runs, downstream channel hops, and terminal completion. That made it hard to answer basic questions like which process touched a request, what it emitted next, and where the flow stopped.

Summary

- add `/api/cogents/{name}/request-flows` to build request-centric graphs from messages, deliveries, and runs
- register the new backend route and return request nodes, process nodes, edges, and timeline entries keyed by `request_id`
- add a Requests tab in the dashboard with filtering, refresh, and recursive rendering of processes plus bridging events
- add backend route coverage, request-flow endpoint tests, and frontend API/type wiring

Testing

- `uv run pytest tests/dashboard/test_routers_request_flows.py tests/dashboard/test_web_proxy.py tests/dashboard/test_integration.py tests/dashboard/test_routers_core.py tests/dashboard/test_routers_events.py`
- `cd dashboard/frontend && npm run type-check`