### PR TITLE
fix(discord): remove legacy scheduler daemon and harden dispatch

### DIFF
--- a/images/cogent-v1/cogos/init.py
+++ b/images/cogent-v1/cogos/init.py
@@ -14,19 +14,9 @@ channels.create("io:web:request")
 
 # ── Infrastructure ───────────────────────────────────────────
 
-scheduler_data = file.read("cogos/lib/scheduler.md")
-if hasattr(scheduler_data, 'error'):
-    print(f"WARN: scheduler prompt not found: {scheduler_data.error}")
-else:
-    r = procs.spawn("scheduler",
-        mode="daemon",
-        content=scheduler_data.content,
-        priority=100.0,
-        model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
-        capabilities={"scheduler": None, "channels": None},
-        subscribe="system:tick:minute")
-    if hasattr(r, 'error'):
-        print(f"WARN: scheduler spawn failed: {r.error}")
+# The dispatcher Lambda already owns matching and dispatch. Do not spawn the
+# legacy LLM scheduler daemon here or it can create orphaned runs without
+# invoking executors.
 
 supervisor_data = file.read("apps/supervisor/supervisor.md")
 if hasattr(supervisor_data, 'error'):

--- a/images/cogent-v1/init/processes.py
+++ b/images/cogent-v1/init/processes.py
@@ -11,7 +11,7 @@ add_process(
     capabilities=[
         "me", "procs", "dir", "file", "discord", "channels",
         "secrets", "stdlib", "coglet_factory", "coglet", "alerts",
-        "blob", "image", "scheduler",
+        "blob", "image",
         # Delegatable to supervisor → helpers:
         "asana", "email", "github", "web_search", "web_fetch",
     ],

--- a/src/cogos/db/migrations/015_run_metadata.sql
+++ b/src/cogos/db/migrations/015_run_metadata.sql
@@ -1,0 +1,4 @@
+-- Add metadata to cogos_run so dispatcher dead-letter reporting can mark runs
+-- as already reported without crashing older stacks.
+ALTER TABLE cogos_run
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}';

--- a/src/cogtainer/lambdas/dispatcher/handler.py
+++ b/src/cogtainer/lambdas/dispatcher/handler.py
@@ -200,7 +200,14 @@ def _flush_dead_letters(repo) -> int:
         # Mark as reported to avoid duplicate dead-letters
         run_meta = run.metadata or {}
         run_meta["dead_letter_reported"] = True
-        repo.update_run_metadata(run.id, run_meta)
+        try:
+            repo.update_run_metadata(run.id, run_meta)
+        except Exception:
+            logger.warning(
+                "Failed to persist dead-letter metadata for run %s; continuing",
+                run.id,
+                exc_info=True,
+            )
         flushed += 1
 
     return flushed

--- a/tests/cogos/test_discord_cog_image.py
+++ b/tests/cogos/test_discord_cog_image.py
@@ -37,6 +37,17 @@ class TestDiscordCogImage:
         init_py = Path("images/cogent-v1/cogos/init.py").read_text()
         assert "discord-handle-message" not in init_py
 
+    def test_no_legacy_scheduler_spawn_in_init(self):
+        """Dispatcher Lambda owns scheduling; init.py must not spawn a scheduler daemon."""
+        init_py = Path("images/cogent-v1/cogos/init.py").read_text()
+        assert 'procs.spawn("scheduler"' not in init_py
+
+    def test_init_process_does_not_request_scheduler_capability(self):
+        """The init process should not request the obsolete scheduler capability."""
+        spec = load_image(Path("images/cogent-v1"))
+        init_proc = next(p for p in spec.processes if p["name"] == "init")
+        assert "scheduler" not in init_proc["capabilities"]
+
 
 class TestDiscordCogApply:
     def test_apply_creates_discord_process(self, tmp_path):

--- a/tests/cogtainer/test_dead_letter.py
+++ b/tests/cogtainer/test_dead_letter.py
@@ -63,6 +63,35 @@ def test_flush_dead_letters_skips_already_reported(tmp_path):
     assert _flush_dead_letters(repo) == 0
 
 
+def test_flush_dead_letters_tolerates_metadata_write_failure(tmp_path, monkeypatch):
+    """Dead-letter flushing should not crash if run metadata cannot be persisted."""
+    from cogtainer.lambdas.dispatcher.handler import _flush_dead_letters
+
+    repo = _repo(tmp_path)
+
+    process = Process(name="worker", mode=ProcessMode.ONE_SHOT, status=ProcessStatus.COMPLETED)
+    repo.upsert_process(process)
+
+    run = Run(process=process.id, status=RunStatus.FAILED, error="boom")
+    repo.create_run(run)
+    repo.complete_run(run.id, status=RunStatus.FAILED, error="boom")
+
+    monkeypatch.setattr(
+        repo,
+        "update_run_metadata",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("no metadata column")),
+    )
+
+    flushed = _flush_dead_letters(repo)
+    assert flushed == 1
+
+    dl_ch = repo.get_channel_by_name("system:dead-letter")
+    assert dl_ch is not None
+    msgs = repo.list_channel_messages(dl_ch.id, limit=10)
+    assert len(msgs) == 1
+    assert msgs[0].payload["type"] == "executor:failed"
+
+
 def test_flush_dead_letters_ignores_completed_runs(tmp_path):
     """Completed runs are not flushed."""
     from cogtainer.lambdas.dispatcher.handler import _flush_dead_letters


### PR DESCRIPTION
## Problem

The Discord path had two independent schedulers in prod: the dispatcher Lambda and a legacy LLM `scheduler` daemon spawned from image init. That daemon could call `scheduler.dispatch_process()` directly, which creates runs and marks deliveries queued without invoking the executor Lambda. In practice, a Discord handler could get stuck in `running` behind an orphaned run, and later mentions would sit pending even though the bridge had accepted them.

The dispatcher also assumed `cogos_run.metadata` existed when flushing dead letters. Older stacks without that column could crash the minute dispatcher after a failed or timed-out run, which stopped normal message draining right when recovery was needed.

## Summary

- stop spawning the legacy scheduler daemon from image init and remove the now-unused `scheduler` capability from the `init` process
- add image regressions so `init.py` cannot reintroduce the legacy scheduler path by accident
- make dead-letter metadata persistence best-effort so dispatcher ticks continue even if a stack is missing the column
- add `015_run_metadata.sql` so older databases gain `cogos_run.metadata` and the runtime/schema contract matches current code

## Testing

- `uv run pytest tests/cogtainer/test_dead_letter.py -q`
- `uv run pytest tests/cogos/test_discord_cog_image.py -q tests/cogos/test_supervisor_image.py -q tests/cogos/test_recruiter_image.py -q`
