### PR TITLE
fix(web): stop published site links from guessing the base URL

### DIFF
--- a/images/cogent-v1/apps/discord/handler/main.md
+++ b/images/cogent-v1/apps/discord/handler/main.md
@@ -8,7 +8,7 @@ You are the Discord message handler for dr.alpha. Process the message in the pay
 - Variables **persist** between `run_code` calls.
 - Available objects: `discord`, `channels`, `data` (dir), `file`, `stdlib`, `procs`, `image`, `blob`, `secrets`, `web`.
 - `data` is a directory scoped to `data/discord/`. Use `data.get("key")` to get a file handle, then `.read()`, `.write(content)`, `.append(text)`.
-- `web` lets you publish websites: `web.publish(path, content)` publishes HTML/CSS/JS at `web/{path}`. `web.list()` shows published files. `web.unpublish(path)` removes a file. Published pages are available at the cogent's web URL.
+- `web` lets you publish websites: `web.publish(path, content)` publishes HTML/CSS/JS at `web/{path}`. `web.url(path)` returns the exact public URL for that page under `/web/static/`. `web.list()` shows published files. `web.unpublish(path)` removes a file.
 - Use `stdlib.time.time()` for timestamps. Use `stdlib.time.strftime(...)` for formatting.
 - Pydantic models: access fields with `.field_name`, not `.get("field_name")`.
 
@@ -93,7 +93,7 @@ print("Done")
 - General knowledge questions (time, greetings, simple facts)
 - System questions you CAN answer: use `procs.list()` for processes, `channels.list()` for channels
 - Simple conversation
-- User asks you to build/create a website or web page — use `web.publish(path, html_content)` to publish it, then share the link
+- User asks you to build/create a website or web page — use `web.publish(path, html_content)` to publish it, then share `web.url(path)` for the published page. Do NOT invent or guess the domain or route.
 
 **Escalate** when:
 - User needs a capability you don't have (email, web search, github, asana)
@@ -109,6 +109,7 @@ Only respond if the message is clearly intended for you. General chat between us
 ## Key rules
 
 - Be concise and friendly
+- If you publish a site, use `web.url(...)` for the link you send back. Example: publish `fruit/index.html`, then share `web.url("fruit")`.
 - **Exactly 2 run_code calls**: Step 1 (parse + waterline + history) then Step 2 (respond + update state). No exploration, no search(), no extra calls.
 - Never use `import` — json and all capabilities are pre-loaded
 - Use `data.get("key")` for scoped file access (auto-prefixed to `data/discord/`)

--- a/src/cogos/capabilities/registry.py
+++ b/src/cogos/capabilities/registry.py
@@ -1047,15 +1047,17 @@ BUILTIN_CAPABILITIES: list[dict] = [
             "Use web to publish static files and handle HTTP API requests.\n"
             "- web.publish(path, content) — publish a file at web/{path}\n"
             "- web.unpublish(path) — remove a published file\n"
+            "- web.url(path?) — return the exact public /web/static URL for a published file or directory\n"
             "- web.respond(request_id, status, headers, body) — respond to an API request\n"
             "- web.list(prefix) — list published files\n"
-            "Static files are served at https://{cogent}.softmax-cogents.com/{path}.\n"
-            "API requests to /api/* are delivered via io:web:request channel."
+            "Static files are served under the cogent's public /web/static/* URL.\n"
+            "Use web.url(path) instead of guessing the hostname or route.\n"
+            "API requests to /web/api/* are delivered via io:web:request channel."
         ),
         "schema": {
             "scope": {
                 "properties": {
-                    "ops": {"type": "array", "items": {"type": "string", "enum": ["publish", "unpublish", "respond", "list"]}},
+                    "ops": {"type": "array", "items": {"type": "string", "enum": ["publish", "unpublish", "respond", "list", "url"]}},
                     "path_prefix": {"type": "string", "description": "Restrict to files under this prefix"},
                 },
             },

--- a/src/cogos/io/web/capability.py
+++ b/src/cogos/io/web/capability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 from pydantic import BaseModel
 
@@ -35,7 +36,7 @@ class WebError(BaseModel):
 
 
 class WebCapability(Capability):
-    ALL_OPS = {"publish", "unpublish", "respond", "list"}
+    ALL_OPS = {"publish", "unpublish", "respond", "list", "url"}
 
     def __init__(self, repo, process_id, **kwargs):
         super().__init__(repo, process_id, **kwargs)
@@ -155,3 +156,31 @@ class WebCapability(Capability):
         files = store.list_files(prefix=full_prefix)
         paths = [f.key.removeprefix("web/") for f in files]
         return ListResult(files=paths)
+
+    def url(self, path: str = "") -> str:
+        """Return the public URL for a published static file or directory."""
+        self._check("url")
+
+        base_url = self._static_base_url()
+        normalized = path.strip().lstrip("/")
+        if not normalized:
+            return base_url
+        return f"{base_url}/{normalized}"
+
+    def _static_base_url(self) -> str:
+        override = (os.environ.get("WEB_BASE_URL") or "").strip().rstrip("/")
+        if override:
+            return override
+
+        if os.environ.get("USE_LOCAL_DB") == "1":
+            frontend_port = (os.environ.get("DASHBOARD_FE_PORT") or "").strip()
+            backend_port = (os.environ.get("DASHBOARD_BE_PORT") or "").strip()
+            if frontend_port:
+                return f"http://localhost:{frontend_port}/web/static"
+            if backend_port:
+                return f"http://localhost:{backend_port}/web/static"
+
+        cogent_name = (os.environ.get("COGENT_NAME") or "").strip()
+        safe_name = cogent_name.replace(".", "-") if cogent_name else "local"
+        domain = (os.environ.get("COGENT_DOMAIN") or "softmax-cogents.com").strip() or "softmax-cogents.com"
+        return f"https://{safe_name}.{domain}/web/static"

--- a/src/cogtainer/cdk/constructs/compute.py
+++ b/src/cogtainer/cdk/constructs/compute.py
@@ -92,6 +92,7 @@ class ComputeConstruct(Construct):
         env = {
             "COGENT_NAME": config.cogent_name,
             "COGENT_ID": config.cogent_name,
+            "COGENT_DOMAIN": config.domain,
             "DB_CLUSTER_ARN": db_cluster_arn,
             "DB_RESOURCE_ARN": db_cluster_arn,
             "DB_SECRET_ARN": db_secret_arn,

--- a/tests/cogos/io/web/test_capability.py
+++ b/tests/cogos/io/web/test_capability.py
@@ -242,3 +242,29 @@ class TestScopeNarrowing:
 
         result = scoped.publish("allowed/x.html", "ok")
         assert isinstance(result, PublishResult)
+
+
+class TestUrl:
+    def test_url_uses_explicit_override(self, cap, monkeypatch):
+        monkeypatch.setenv("WEB_BASE_URL", "https://example.com/custom/web/static/")
+
+        assert cap.url("page.html") == "https://example.com/custom/web/static/page.html"
+
+    def test_url_defaults_to_cogent_dashboard_static_path(self, cap, monkeypatch):
+        monkeypatch.delenv("WEB_BASE_URL", raising=False)
+        monkeypatch.delenv("USE_LOCAL_DB", raising=False)
+        monkeypatch.delenv("DASHBOARD_FE_PORT", raising=False)
+        monkeypatch.delenv("DASHBOARD_BE_PORT", raising=False)
+        monkeypatch.setenv("COGENT_NAME", "dr.gamma")
+        monkeypatch.setenv("COGENT_DOMAIN", "softmax-cogents.com")
+
+        assert cap.url("least-favorite-fruit") == (
+            "https://dr-gamma.softmax-cogents.com/web/static/least-favorite-fruit"
+        )
+
+    def test_url_prefers_local_frontend_port(self, cap, monkeypatch):
+        monkeypatch.delenv("WEB_BASE_URL", raising=False)
+        monkeypatch.setenv("USE_LOCAL_DB", "1")
+        monkeypatch.setenv("DASHBOARD_FE_PORT", "5200")
+
+        assert cap.url("demo") == "http://localhost:5200/web/static/demo"

--- a/tests/cogos/test_discord_cog_image.py
+++ b/tests/cogos/test_discord_cog_image.py
@@ -42,6 +42,11 @@ class TestDiscordCogImage:
         init_py = Path("images/cogent-v1/cogos/init.py").read_text()
         assert 'procs.spawn("scheduler"' not in init_py
 
+    def test_discord_handler_prompt_uses_web_url_helper(self):
+        prompt = Path("images/cogent-v1/apps/discord/handler/main.md").read_text()
+        assert "web.url(path)" in prompt
+        assert "Do NOT invent or guess the domain or route." in prompt
+
     def test_init_process_does_not_request_scheduler_capability(self):
         """The init process should not request the obsolete scheduler capability."""
         spec = load_image(Path("images/cogent-v1"))


### PR DESCRIPTION
Problem
The Discord website flow told the model to share a link without giving it the real public URL shape.

Deployed cogents currently publish under https://<safe-name>.softmax-cogents.com/web/static/..., so the model could hallucinate hosts like cogent.sh or omit /web/static/.

Summary
- add web.url(path) so processes can ask runtime for the exact public static URL instead of inferring host/path
- update the web capability instructions and Discord handler prompt to use web.url(...) and explicitly forbid guessing the domain or route
- pass COGENT_DOMAIN into runtime env and cover the new helper and prompt behavior with focused tests

Testing
- uv run pytest tests/cogos/io/web/test_capability.py tests/cogos/test_discord_cog_image.py -q