### PR TITLE
fix(discord): kick review after reload

### DIFF
--- a/images/cogent-v1/cogos/init.py
+++ b/images/cogent-v1/cogos/init.py
@@ -4,6 +4,7 @@
 # ── Channels (created at boot so handlers can subscribe) ──────
 for ch_name in [
     "io:discord:dm", "io:discord:mention", "io:discord:message",
+    "discord-cog:review",
     "system:tick:minute", "system:tick:hour",
     "supervisor:help",
 ]:
@@ -40,6 +41,10 @@ else:
         print(f"WARN: supervisor spawn failed: {r.error}")
 
 # ── Apps are now cogs (created by apply_image from apps/*/init/cog.py) ──
+
+# Kick the Discord root cog once after boot so it can recreate runtime child
+# processes like discord/handler immediately after a reload.
+channels.send("discord-cog:review", {"reason": "boot"})
 
 # ── Coglets ──────────────────────────────────────────────────
 

--- a/tests/cogos/test_discord_cog_image.py
+++ b/tests/cogos/test_discord_cog_image.py
@@ -42,6 +42,12 @@ class TestDiscordCogImage:
         init_py = Path("images/cogent-v1/cogos/init.py").read_text()
         assert 'procs.spawn("scheduler"' not in init_py
 
+    def test_init_kicks_discord_review_after_boot(self):
+        """Reload should wake the Discord root cog immediately to recreate its runtime children."""
+        init_py = Path("images/cogent-v1/cogos/init.py").read_text()
+        assert '"discord-cog:review"' in init_py
+        assert 'channels.send("discord-cog:review", {"reason": "boot"})' in init_py
+
     def test_discord_handler_prompt_uses_web_url_helper(self):
         prompt = Path("images/cogent-v1/apps/discord/handler/main.md").read_text()
         assert "web.url(path)" in prompt


### PR DESCRIPTION
Problem

`cogos reload` recreates the image-managed `discord` root cog, but `discord/handler` is still a runtime child. That meant a reload could come back with Discord only half-booted until the next `system:tick:hour` or a manual `discord-cog:review` wake-up.

Summary

- create the `discord-cog:review` channel during init boot
- send a one-shot `discord-cog:review` message from init so the root Discord cog recreates `discord/handler` immediately after reload
- add a regression test that pins the boot review kick in the image

Testing

- `uv run pytest tests/cogos/test_discord_cog_image.py -q`
- `uv run pytest tests/cogos/test_supervisor_image.py -q tests/cogos/test_recruiter_image.py -q`
