### PR TITLE
fix discord escalation: add web cap to init, dynamic supervisor caps, handler ack

### DIFF
--- a/images/cogent-v1/apps/discord/handler/main.md
+++ b/images/cogent-v1/apps/discord/handler/main.md
@@ -64,6 +64,8 @@ discord.send(channel=channel_id, content=reply, reply_to=message_id)
 # discord.react(channel=channel_id, message_id=message_id, emoji="👍")
 
 # Option C — Escalate (when you lack capability or info):
+# reply = "On it — handing this off now!"
+# discord.send(channel=channel_id, content=reply, reply_to=message_id)
 # discord.react(channel=channel_id, message_id=message_id, emoji="⬆️")
 # channels.send("supervisor:help", {
 #     "process_name": "discord-handle-message",
@@ -90,17 +92,19 @@ print("Done")
 ## When to escalate vs respond directly
 
 **Respond directly** when:
+
 - General knowledge questions (time, greetings, simple facts)
 - System questions you CAN answer: use `procs.list()` for processes, `channels.list()` for channels
 - Simple conversation
 - User asks you to build/create a website or web page — use `web.publish(path, html_content)` to publish it, then share `web.url(path)` for the published page. Do NOT invent or guess the domain or route.
 
 **Escalate** when:
+
 - User needs a capability you don't have (email, web search, github, asana)
 - The request requires action beyond your scope
 - You don't know the answer and guessing would be wrong
 
-When escalating, react with ⬆️ and send to `supervisor:help` — do NOT send a text reply.
+When escalating, react with ⬆️, send a brief reply (e.g. "On it — handing this off now!"), and send to `supervisor:help`.
 
 ## Channel messages (not DM, not mention)
 

--- a/images/cogent-v1/apps/supervisor/supervisor.md
+++ b/images/cogent-v1/apps/supervisor/supervisor.md
@@ -43,11 +43,31 @@ print(f"Context: {context}")
 
 ```python
 # Determine what capabilities the helper needs based on the description
-# Common mappings:
+# Always include discord + channels (for replying and escalation).
+# Add others based on keywords:
 #   "task" / "asana" → asana
 #   "email" / "send mail" → email
-#   "search" / "look up" → web_search
+#   "search" / "look up" → web_search, web_fetch
 #   "github" / "repo" → github
+#   "site" / "website" / "page" / "publish" → web, blob
+#   "image" / "picture" / "photo" → image, blob
+caps = {"discord": None, "channels": None}
+desc_lower = description.lower()
+if any(w in desc_lower for w in ["task", "asana"]):
+    caps["asana"] = None
+if any(w in desc_lower for w in ["email", "send mail", "mail"]):
+    caps["email"] = None
+if any(w in desc_lower for w in ["search", "look up", "lookup", "find info"]):
+    caps["web_search"] = None
+    caps["web_fetch"] = None
+if any(w in desc_lower for w in ["github", "repo", "pull request", "pr", "issue"]):
+    caps["github"] = None
+if any(w in desc_lower for w in ["site", "website", "page", "publish", "web"]):
+    caps["web"] = None
+    caps["blob"] = None
+if any(w in desc_lower for w in ["image", "picture", "photo", "generate"]):
+    caps["image"] = None
+    caps["blob"] = None
 
 # Spawn a helper with the needed capabilities
 helper = procs.spawn(
@@ -70,7 +90,7 @@ channels.send("supervisor:help", {{
     "discord_author_id": "{discord_author_id}",
 }})
 """,
-    capabilities={"asana": None, "channels": None, "discord": None},
+    capabilities=caps,
 )
 
 # Check spawn result

--- a/images/cogent-v1/init/processes.py
+++ b/images/cogent-v1/init/processes.py
@@ -13,6 +13,6 @@ add_process(
         "secrets", "stdlib", "coglet_factory", "coglet", "alerts",
         "blob", "image",
         # Delegatable to supervisor → helpers:
-        "asana", "email", "github", "web_search", "web_fetch",
+        "asana", "email", "github", "web_search", "web_fetch", "web",
     ],
 )

--- a/tests/cogos/test_supervisor_delegation.py
+++ b/tests/cogos/test_supervisor_delegation.py
@@ -9,14 +9,15 @@ the supervisor must hold asana, and init must hold asana (to delegate to supervi
 
 from pathlib import Path
 
-from cogos.capabilities.procs import ProcsCapability, ProcessError
+from cogos.capabilities.procs import ProcessError, ProcsCapability
 from cogos.db.local_repository import LocalRepository
-from cogos.db.models import ProcessCapability
 from cogos.image.apply import apply_image
 from cogos.image.spec import load_image
 
-
-DELEGATABLE_CAPS = ["asana", "email", "github", "web_search", "web_fetch"]
+DELEGATABLE_CAPS = [
+    "asana", "email", "github", "web_search", "web_fetch",
+    "web", "blob", "image",
+]
 
 
 def _boot_cogent_v1(tmp_path):
@@ -53,7 +54,7 @@ def test_init_can_spawn_supervisor_with_delegatable_caps(tmp_path):
         "discord": None, "channels": None, "secrets": None,
         "stdlib": None, "alerts": None,
         "asana": None, "email": None, "github": None,
-        "web_search": None, "web_fetch": None,
+        "web_search": None, "web_fetch": None, "web": None,
         "blob": None, "image": None,
     }
 


### PR DESCRIPTION
- Add web to init delegatable capabilities so supervisor can receive it
- Supervisor now selects helper capabilities dynamically based on request keywords
- Handler sends brief Discord reply when escalating (user was getting zero feedback)
- Update delegation tests to cover web/blob/image

Co-Authored-By: Claude <noreply@anthropic.com>