### PR TITLE
fix orchestrator inline tick referencing nonexistent event_id

### DIFF
--- a/src/cogtainer/lambdas/orchestrator/handler.py
+++ b/src/cogtainer/lambdas/orchestrator/handler.py
@@ -296,10 +296,10 @@ def _cogos_scheduler_tick(config) -> None:
                 continue
 
             event_payload = {}
-            if dispatch_result.event_id:
+            if dispatch_result.message_id:
                 rows = cogos_repo._rows_to_dicts(cogos_repo._execute(
                     "SELECT payload FROM cogos_channel_message WHERE id = :id",
-                    [cogos_repo._param("id", _UUID(dispatch_result.event_id))],
+                    [cogos_repo._param("id", _UUID(dispatch_result.message_id))],
                 ))
                 if rows:
                     raw = rows[0].get("payload", "{}")
@@ -308,7 +308,7 @@ def _cogos_scheduler_tick(config) -> None:
             payload = {
                 "process_id": dispatch_result.process_id,
                 "run_id": dispatch_result.run_id,
-                "event_id": dispatch_result.event_id,
+                "event_id": dispatch_result.message_id,
                 "trace_id": getattr(dispatch_result, "trace_id", None),
                 "dispatched_at_ms": int(time.time() * 1000),
                 "event_type": event_payload.get("event_type", ""),


### PR DESCRIPTION
## Summary

- The orchestrator's `_cogos_scheduler_tick` referenced `dispatch_result.event_id`, but `DispatchResult` only has `message_id`
- This caused a silent `AttributeError` caught by the broad `except Exception` clause
- Since `dispatch_process()` already ran before the crash, the process was left stuck in RUNNING with an orphaned Run record for up to 15 minutes (until `timeout_stale_runs` reaped it)
- This defeated the purpose of the inline tick — all CogOS processes had to wait for the 60s dispatcher tick instead of being dispatched immediately on EventBridge events

## Test plan

- [ ] Deploy and send a Discord message — handler should be dispatched immediately (not after 60s)
- [ ] Verify no `AttributeError` in orchestrator CloudWatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)