### PR TITLE
Grant dashboard access to gemini secret

### DIFF
--- a/src/cogtainer/cdk/stack.py
+++ b/src/cogtainer/cdk/stack.py
@@ -378,6 +378,12 @@ class CogtainerStack(Stack):
         )
         task_def.task_role.add_to_policy(
             iam.PolicyStatement(
+                actions=["secretsmanager:GetSecretValue"],
+                resources=[f"arn:aws:secretsmanager:{config.region}:{config.account}:secret:cogent/{config.cogent_name}/gemini-*"],
+            )
+        )
+        task_def.task_role.add_to_policy(
+            iam.PolicyStatement(
                 actions=["ecs:DescribeServices"],
                 resources=["*"],
             )


### PR DESCRIPTION
## Summary
- The dashboard ECS task role only had `GetSecretValue` for `dashboard-api-key-*` and `discord-*` secrets
- The new Gemini setup section (#82) needs to read `cogent/{name}/gemini-*` to check if the API key is configured
- Adds the missing IAM policy statement

## Test plan
- [ ] Deploy CDK stack: `uv run cogent dr.gamma cogtainer create --watch`
- [ ] Visit `https://dr-gamma.softmax-cogents.com/#setup` and click "Image Generation" tab
- [ ] Confirm it no longer shows "AccessDeniedException" and instead shows "Needs setup" or "Ready"

🤖 Generated with [Claude Code](https://claude.com/claude-code)