### PR TITLE
child exit notification design

### DIFF
--- a/docs/plans/2026-03-18-child-completion-notification-design.md
+++ b/docs/plans/2026-03-18-child-completion-notification-design.md
@@ -6,7 +6,7 @@ When the supervisor spawns a helper, it's fire-and-forget. The helper can silent
 
 More broadly, any parent that spawns children has no reliable way to learn the outcome. `handle.wait()` exists as an API but the executor never interprets the return value. `handle.status()` requires the parent to poll. There is no push-based notification on success.
 
-Failure notification partially exists: `_notify_parent_on_failure` sends a `child:failed` message on the spawn channel. But nothing wakes the parent to read it, and no equivalent exists for success.
+Failure notification partially exists: `_notify_parent_on_failure` sends a `child:failed` message on the spawn channel. But nothing wakes the parent to read it, no equivalent exists for success, and the message type splits success/failure into separate events rather than using a unified signal with an exit code.
 
 ## How operating systems solve this
 
@@ -22,23 +22,30 @@ The key insight: the OS doesn't give the parent a way to *inspect* children. It 
 
 Apply the SIGCHLD pattern to CogOS. When a child completes (success or failure), CogOS automatically notifies the parent via the spawn channel and wakes it.
 
-### Change 1: Notify parent on success (not just failure)
+### Change 1: Notify parent on child exit (success and failure)
 
-The executor already calls `_notify_parent_on_failure` in the error path. Add a matching `_notify_parent_on_completion` in the success path that writes to the same spawn channel:
+The executor already calls `_notify_parent_on_failure` in the error path. Replace this with a unified `_notify_parent_on_exit` that fires on both success and failure, with an exit code — mirroring Unix where SIGCHLD fires regardless of how the child exited and `wait()` returns the status.
 
 ```python
 # On spawn:{child_id}→{parent_id}
 {
-    "type": "child:completed",
+    "type": "child:exited",
+    "exit_code": 0,           # 0 = success, 1 = failure, 2 = timeout, 3 = throttled
     "process_name": "helper-task",
     "process_id": "...",
     "run_id": "...",
     "duration_ms": 4500,
-    "result": { ... },  # from run.result, if any
+    "error": null,            # non-null on failure
+    "result": { ... },        # from run.result, if any (null on failure)
 }
 ```
 
-This mirrors the existing `child:failed` message shape. Both success and failure now flow through the same channel.
+Exit codes:
+- `0` — completed successfully
+- `1` — failed (error in `error` field)
+- `2` — timed out
+- `3` — throttled (Bedrock rate limit)
+- `4` — disabled (max retries exceeded)
 
 ### Change 2: Auto-register parent for spawn channel wakeup
 
@@ -62,11 +69,11 @@ This exposes the existing `repo.list_runs(process_id=...)` data through the hand
 
 ## What this means for the supervisor
 
-Today the supervisor wakes only on `supervisor:help` messages. With these changes, it will also wake on spawn channel messages when helpers complete or fail. The message payload includes `"type": "child:completed"` or `"type": "child:failed"`, so the supervisor can distinguish these from help requests.
+Today the supervisor wakes only on `supervisor:help` messages. With these changes, it will also wake on spawn channel messages when helpers exit. The message payload has `"type": "child:exited"` with an `exit_code`, so the supervisor can distinguish these from help requests and branch on the outcome.
 
-The supervisor image needs a new section for handling child notifications:
-- On `child:completed`: log success, optionally notify Discord
-- On `child:failed`: check the error, decide whether to re-spawn or escalate to human
+The supervisor image needs a new section for handling child exit notifications:
+- `exit_code == 0`: success — log it, optionally notify Discord
+- `exit_code != 0`: failure — check the error, decide whether to re-spawn or escalate to human
 
 This eliminates the need for helpers to self-report failure — the OS (CogOS) handles it.
 
@@ -78,7 +85,7 @@ This eliminates the need for helpers to self-report failure — the OS (CogOS) h
 
 ## Files to change
 
-1. `src/cogos/executor/handler.py` — add `_notify_parent_on_completion`, call it in the success path
+1. `src/cogos/executor/handler.py` — replace `_notify_parent_on_failure` with `_notify_parent_on_exit`, call it in both success and failure paths
 2. `src/cogos/capabilities/procs.py` — in `spawn()`, create Handler for parent on recv channel
 3. `src/cogos/capabilities/process_handle.py` — add `runs()` method returning run history
 4. `images/cogent-v1/apps/supervisor/supervisor.md` — add child notification handling section

--- a/images/cogent-v1/apps/supervisor/supervisor.md
+++ b/images/cogent-v1/apps/supervisor/supervisor.md
@@ -91,53 +91,50 @@ else:
     alerts.warning("supervisor", f"Escalation from {process_name}: {description}")
 ```
 
-## On Child Completion/Failure Notification
+## On Child Exit Notification
 
-CogOS automatically notifies you when a helper you spawned completes or fails. These arrive as messages on the spawn channel with `"type": "child:completed"` or `"type": "child:failed"` in the payload.
+CogOS automatically notifies you when a helper you spawned exits. These arrive as messages on the spawn channel with `"type": "child:exited"` in the payload, along with an `exit_code` (0 = success, non-zero = failure) and the child's `process_id` and `run_id`.
 
 Check the payload type first to distinguish these from help requests.
 
-### Handling child notifications (single run_code call)
+### Handling child exit (single run_code call)
 
 ```python
 payload = ...  # from "Message payload:" in user message above
 msg_type = payload.get("type", "")
 
-if msg_type == "child:completed":
-    # Helper finished successfully — nothing to do unless you want to log it
-    print(f"Helper {payload.get('process_name')} completed in {payload.get('duration_ms')}ms")
-
-elif msg_type == "child:failed":
-    # Helper crashed — check the error and decide whether to retry
+if msg_type == "child:exited":
     process_name = payload.get("process_name", "unknown")
-    error = payload.get("error", "unknown error")
     process_id = payload.get("process_id", "")
-    print(f"Helper {process_name} failed: {error}")
+    exit_code = payload.get("exit_code", -1)
+    error = payload.get("error")
 
-    # Check run history to see if this is a repeated failure
-    h = procs.get(id=process_id)
-    if hasattr(h, 'error'):
-        print(f"Could not look up helper: {h.error}")
-        alerts.error("supervisor", f"Helper {process_name} failed and could not be inspected: {error}")
+    if exit_code == 0:
+        # Helper finished successfully
+        print(f"Helper {process_name} completed in {payload.get('duration_ms')}ms")
     else:
-        # Inspect what happened — use runs() to see history
-        runs = h.runs(limit=3)
-        print(f"Run history: {json.dumps([{'status': r.status, 'error': r.error} for r in runs])}")
+        # Helper failed — check run history and escalate
+        print(f"Helper {process_name} exited with code {exit_code}: {error}")
 
-        # Escalate to humans via alert
-        alerts.error("supervisor", f"Helper {process_name} failed: {error}")
+        h = procs.get(id=process_id)
+        if hasattr(h, 'error'):
+            alerts.error("supervisor", f"Helper {process_name} failed (exit {exit_code}): {error}")
+        else:
+            runs = h.runs(limit=3)
+            print(f"Run history: {json.dumps([{'status': r.status, 'error': r.error} for r in runs])}")
+            alerts.error("supervisor", f"Helper {process_name} failed (exit {exit_code}): {error}")
 
 else:
-    # Not a child notification — treat as a help request (fall through to normal flow)
+    # Not a child exit — treat as a help request (fall through to normal flow below)
     pass
 ```
 
-If the payload type is neither `child:completed` nor `child:failed`, fall through to the normal help request flow (Step 1 + Step 2 above).
+If the payload type is not `child:exited`, fall through to the normal help request flow (Step 1 + Step 2 above).
 
 ## Key rules
 
 - **Help requests: exactly 2 run_code calls** — Step 1 (parse + notify) then Step 2 (spawn + alert).
-- **Child notifications: 1 run_code call** — handle and exit.
+- **Child exit notifications: 1 run_code call** — handle and exit.
 - Always check `payload.get("type")` first to determine which flow to use.
 - Never use `import` — json and all capabilities are pre-loaded.
 - Do NOT call `search()`, `print(__capabilities__)`, or explore the environment.


### PR DESCRIPTION
## Summary
- Design doc for automatic child exit notification (SIGCHLD pattern for CogOS)
- When a child process exits, CogOS sends a unified `child:exited` event with an exit code on the spawn channel and wakes the parent
- Updates supervisor image to handle child exit notifications and branch on exit code
- Adds `handle.runs()` to ProcessHandle spec for run history inspection

## Motivation
Supervisor spawns helpers fire-and-forget. Helpers can silently die — the supervisor never knows and never retries. This applies the Unix SIGCHLD pattern: one event type (`child:exited`), exit codes (0=success, 1=failed, 2=timeout, 3=throttled, 4=disabled), automatic parent wakeup via spawn channel Handler.

## Test plan
- [ ] Review design doc for completeness
- [ ] Verify supervisor image handles both child exit and help request flows
- [ ] Implementation PR to follow with code changes