### PR TITLE
Clean up dispatch path redundancy and stale docs

### DIFF
--- a/docs/cogos/design.md
+++ b/docs/cogos/design.md
@@ -105,19 +105,15 @@ For normal external messages such as Discord DMs:
 1. A producer appends a row to `cogos_channel_message`.
 2. Handlers bound to that channel are matched.
 3. The producer-side repository sends a coalesced, best-effort wake nudge to the per-cogent ingress queue.
-4. The ingress Lambda drains a batch, loads the corresponding committed channel messages, matches handlers, creates delivery rows idempotently, marks affected WAITING processes RUNNABLE, creates runs, and invokes executors immediately.
+4. The ingress Lambda selects RUNNABLE processes and dispatches them immediately. (Handler matching and delivery creation happen inline in step 2, not in the ingress Lambda.)
 
 ### Coalesced wakeups
 
 The queue message is only a wake signal. It is not the source of truth and does not carry authoritative work state.
 
-At higher message rates we do not want one queue message per channel message. Instead:
+At higher message rates we do not want one queue message per channel message. The current implementation uses SQS FIFO deduplication (timestamp-based `MessageDeduplicationId` with a shared `MessageGroupId`) for best-effort coalescing. The `cogos_ingress_wake` table exists (migration 005) but DB-based coalescing is not yet wired up in the Python code.
 
-- Postgres records the most recent ingress wake request in `cogos_ingress_wake`
-- wake requests are coalesced inside a short cooldown window
-- the ingress Lambda drains as many pending messages as it can in a batch
-
-This means bursts of channel messages still produce a small number of wake messages while pending deliveries remain the real pending-work set.
+The ingress Lambda drains as many pending messages as it can in a batch. Bursts of channel messages still produce a small number of wake messages while pending deliveries remain the real pending-work set.
 
 ### Backstop path
 
@@ -449,7 +445,7 @@ cogos/sandbox/
 
 ## Scheduler
 
-The scheduler is itself a daemon process. It registers for `system:tick:minute` messages and runs the scheduling loop using the `scheduler` capability.
+The scheduler runs as a Lambda (the dispatcher) invoked by EventBridge every 60 seconds. It uses the `scheduler` capability for message matching, process selection, and dispatch.
 
 ### Per-Tick Flow
 
@@ -463,7 +459,7 @@ The scheduler is itself a daemon process. It registers for `system:tick:minute` 
 
 ### System Tick Messages
 
-The dispatcher generates virtual tick messages (not written to channels):
+The dispatcher generates virtual tick messages via `apply_scheduled_messages()`, which writes them to channels using `emit_channel_message()`:
 - `system:tick:minute` -- every invocation
 - `system:tick:hour` -- when minute == 0
 
@@ -569,7 +565,7 @@ The executor uses `process.model` if set, otherwise falls back to a configurable
 
 All state lives in PostgreSQL, accessed via RDS Data API. Tables are prefixed with `cogos_` (process, handler, channel, channel_message, delivery, file, file_version, capability, process_capability, run, resource, resource_usage, schema, cron, conversation, alert, budget, trace).
 
-Channel messages are DB records matched by the scheduler -- no external event bus (EventBridge was eliminated).
+Channel messages are DB records matched by the scheduler -- no external event bus for CogOS-internal messaging (EventBridge was replaced by channels for inter-process communication). EventBridge is still used by the cogtainer layer for orchestrator triggers and dispatcher scheduling.
 
 ## Source Structure
 

--- a/docs/cogtainer/README.md
+++ b/docs/cogtainer/README.md
@@ -80,11 +80,8 @@ Both legacy (cogtainer-layer, from `schema.sql`) and CogOS tables (from `src/cog
 | `cogos_capability` | Capability definitions |
 | `cogos_process` | Process definitions and state |
 | `cogos_process_capability` | Process-capability associations |
-| `cogos_handler` | Event handlers |
-| `cogos_event` | CogOS event log |
-| `cogos_event_type` | Event type registry |
-| `cogos_event_delivery` | Event delivery tracking |
-| `cogos_event_outbox` | Outbound event queue |
+| `cogos_handler` | Channel subscription handlers |
+| `cogos_delivery` | Per-handler message delivery tracking |
 | `cogos_run` | CogOS execution runs |
 | `cogos_trace` | CogOS execution traces |
 | `cogos_meta` | CogOS metadata key-value store |

--- a/src/cogos/capabilities/scheduler.py
+++ b/src/cogos/capabilities/scheduler.py
@@ -94,7 +94,13 @@ class SchedulerCapability(Capability):
     """
 
     def match_messages(self) -> MatchResult:
-        """Find undelivered channel messages and create deliveries."""
+        """Reconciliation backstop: find undelivered channel messages and create deliveries.
+
+        The hot path is append_channel_message() in repository.py, which creates
+        deliveries inline at write time and nudges the ingress queue. This method
+        is called by the dispatcher (every 60s) to catch any messages that were
+        missed by the inline path.
+        """
         all_handlers = self.repo.list_handlers(enabled_only=True)
         channel_handlers = [h for h in all_handlers if h.channel is not None]
 

--- a/src/cogtainer/lambdas/orchestrator/handler.py
+++ b/src/cogtainer/lambdas/orchestrator/handler.py
@@ -73,10 +73,6 @@ def handler(event: dict, context) -> dict:
         logger.exception("Failed to log event to database")
         return {"statusCode": 500, "body": "event_log_failed"}
 
-    # Run a CogOS scheduler tick so handler processes react immediately
-    _cogos_scheduler_tick(config)
-
-
     # Handle task:run events directly — look up task, dispatch its program
     if brain_event.event_type == "task:run":
         return _handle_task_run(config, repo, brain_event, event_id)
@@ -258,77 +254,6 @@ def _dispatch_lambda(config, lambda_client, payload: str, program_name: str):
         Payload=payload.encode(),
     )
     logger.info(f"Dispatched to Lambda: {program_name}")
-
-
-def _cogos_scheduler_tick(config) -> None:
-    """Run one CogOS scheduler tick inline so event-driven processes react immediately."""
-    try:
-        from cogos.db.repository import Repository as CogosRepo
-        from cogos.capabilities.scheduler import SchedulerCapability
-
-        cogos_repo = CogosRepo.create()
-
-        from uuid import UUID as _UUID
-        scheduler = SchedulerCapability(cogos_repo, _UUID("00000000-0000-0000-0000-000000000000"))
-
-        # Match events to handlers
-        match_result = scheduler.match_messages()
-        if match_result.deliveries_created > 0:
-            logger.info(f"CogOS: matched {match_result.deliveries_created} deliveries")
-
-        # Reap idle daemon processes
-        scheduler.reap_idle_processes()
-
-        # Select and dispatch runnable processes
-        select_result = scheduler.select_processes(slots=5)
-        if not select_result.selected:
-            return
-
-        import os as _os
-        lambda_client = boto3.client("lambda", region_name=config.region)
-        safe_name = _os.environ.get("COGENT_NAME", "").replace(".", "-")
-        executor_fn = f"cogent-{safe_name}-executor"
-
-        dispatched = 0
-        for proc in select_result.selected:
-            dispatch_result = scheduler.dispatch_process(process_id=proc.id)
-            if hasattr(dispatch_result, "error"):
-                continue
-
-            event_payload = {}
-            if dispatch_result.message_id:
-                rows = cogos_repo._rows_to_dicts(cogos_repo._execute(
-                    "SELECT payload FROM cogos_channel_message WHERE id = :id",
-                    [cogos_repo._param("id", _UUID(dispatch_result.message_id))],
-                ))
-                if rows:
-                    raw = rows[0].get("payload", "{}")
-                    event_payload = json.loads(raw) if isinstance(raw, str) else (raw or {})
-
-            payload = {
-                "process_id": dispatch_result.process_id,
-                "run_id": dispatch_result.run_id,
-                "event_id": dispatch_result.message_id,
-                "trace_id": getattr(dispatch_result, "trace_id", None),
-                "dispatched_at_ms": int(time.time() * 1000),
-                "event_type": event_payload.get("event_type", ""),
-                "payload": event_payload,
-            }
-
-            try:
-                lambda_client.invoke(
-                    FunctionName=executor_fn,
-                    InvocationType="Event",
-                    Payload=json.dumps(payload),
-                )
-                dispatched += 1
-            except Exception:
-                logger.exception(f"CogOS: failed to invoke executor for {proc.name}")
-
-        if dispatched:
-            logger.info(f"CogOS: inline tick dispatched {dispatched} processes")
-    except Exception:
-        logger.debug("CogOS scheduler tick skipped", exc_info=True)
 
 
 def _dispatch_ecs(config, ecs_client, payload: str, program_name: str,


### PR DESCRIPTION
## Summary

Closes #87

- **Remove `_cogos_scheduler_tick()` from orchestrator** — this ~70-line function duplicated the dispatcher's message matching, process selection, and dispatch logic inline on every EventBridge event. The inline+ingress path (append_channel_message -> nudge SQS -> ingress Lambda) handles immediate dispatch; the dispatcher Lambda handles reconciliation every 60s. The orchestrator no longer needs its own dispatch path.

- **Clarify `scheduler.match_messages()` as a backstop** — added docstring explaining that the hot path is inline delivery creation in `append_channel_message()`, and this method is the reconciliation backstop called by the dispatcher.

- **Fix 5 stale sections in `docs/cogos/design.md`**:
  - Ingress Lambda description: it selects/dispatches, doesn't match handlers or create deliveries
  - Coalesced wakeups: notes that `cogos_ingress_wake` table exists but isn't wired up; actual coalescing uses SQS FIFO dedup
  - Scheduler description: it's a Lambda invoked by EventBridge, not a daemon process
  - Tick messages: they ARE written to channels via `emit_channel_message()`, not virtual
  - EventBridge: clarified it was eliminated as CogOS-internal transport (replaced by channels), but still used by cogtainer layer

- **Fix stale table list in `docs/cogtainer/README.md`** — removed `cogos_event`, `cogos_event_type`, `cogos_event_delivery`, `cogos_event_outbox` (dropped when channels replaced events). Added `cogos_delivery` (renamed in migration 009).

## Test plan

- [ ] Deploy to staging and verify cogent processes still dispatch correctly via ingress (Discord DM triggers)
- [ ] Verify dispatcher Lambda still runs reconciliation ticks every 60s
- [ ] Confirm orchestrator still handles EventBridge events and trigger matching (just no longer runs inline CogOS dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)