### PR TITLE
remove broken --watch flag from cogtainer create

### DIFF
--- a/.claude/commands/deploy.cogtainer.md
+++ b/.claude/commands/deploy.cogtainer.md
@@ -31,7 +31,7 @@ If the change doesn't require a cogtainer deploy, tell the user and suggest the 
 ```bash
 # Full CDK stack deploy (creates/updates all infra: Lambda, ECS, RDS, ALB, etc.)
 # This is slow (~3-5 min). Only use when infra definition changed.
-cogent <name> cogtainer create --watch
+cogent <name> cogtainer create
 
 # Build and push executor Docker image to ECR (without CDK deploy)
 cogent <name> cogtainer build
@@ -54,7 +54,7 @@ cogent <name> cogtainer status
 
 ## When to use `cogtainer create` vs `cogtainer update`
 
-- **`cogtainer create --watch`**: CDK stack changes — new resources, IAM policy changes, ALB rules, ECS task def changes, env var changes in CDK. This runs `cdk deploy`.
+- **`cogtainer create`**: CDK stack changes — new resources, IAM policy changes, ALB rules, ECS task def changes, env var changes in CDK. This runs `cdk deploy`.
 - **`cogtainer update lambda`**: Only Python code in `src/cogos/` changed. Zips and uploads to existing Lambda.
 - **`cogtainer update ecs`**: Need to restart ECS tasks (e.g. after ECR image push). Does NOT rebuild image.
 - **`cogtainer build` + `cogtainer update ecs`**: Executor Docker image changed (new dependencies, Dockerfile changes).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ See [docs/deploy.md](docs/deploy.md) for the full deploy reference.
 cogent dr.alpha cogtainer update lambda       # Update Lambda code (~15s)
 cogent dr.alpha cogtainer update rds          # Run DB schema migrations
 cogent dr.alpha cogtainer update all          # Lambda + RDS + sync
-cogent dr.alpha cogtainer create --watch      # Full CDK stack deploy (ALB rules, IAM, etc.)
+cogent dr.alpha cogtainer create              # Full CDK stack deploy (ALB rules, IAM, etc.)
 ```
 
 ### Managing the Discord bridge (remote)
@@ -188,7 +188,7 @@ cogent dr.alpha cogos io discord status    # Check running/desired counts
 
 ```bash
 cogent dr.alpha dashboard create-pat
-cogent dr.alpha cogtainer create --watch      # Apply ALB bypass rule
+cogent dr.alpha cogtainer create              # Apply ALB bypass rule
 ```
 
 2. Test with curl:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -11,7 +11,7 @@ Four deployable components:
 | **Lambda functions** | orchestrator, executor, dispatcher, ingress | `cogtainer update lambda` |
 | **Database schema** | Aurora PostgreSQL via RDS Data API | `cogtainer update rds` |
 | **Dashboard** | ECS Fargate on cogent-polis cluster | `dashboard deploy` |
-| **CDK stack** | All infrastructure definitions (IAM, VPC, ALB, ECS task defs) | `cogtainer create --watch` |
+| **CDK stack** | All infrastructure definitions (IAM, VPC, ALB, ECS task defs) | `cogtainer create` |
 
 ## Decision Tree
 
@@ -26,8 +26,8 @@ What changed? Run `git diff HEAD~1 --name-only` and match:
 | `dashboard/frontend/**` | `cogent <name> dashboard deploy` |
 | `src/dashboard/**` | `cogent <name> dashboard deploy --docker` |
 | Both frontend + backend | `cogent <name> dashboard deploy --docker` |
-| `src/cogtainer/cdk/**`, IAM, VPC, ALB changes | `cogent <name> cogtainer create --watch` |
-| `DOCKER_VERSION` changed | `cogent <name> cogtainer create --watch` |
+| `src/cogtainer/cdk/**`, IAM, VPC, ALB changes | `cogent <name> cogtainer create` |
+| `DOCKER_VERSION` changed | `cogent <name> cogtainer create` |
 
 ## Command Reference
 
@@ -43,7 +43,7 @@ cogent <name> cogtainer update all          # Lambda + RDS migrations + sync
 ### CDK Stack
 
 ```bash
-cogent <name> cogtainer create --watch      # Full CDK deploy (~3-5 min)
+cogent <name> cogtainer create              # Full CDK deploy (~3-5 min)
 cogent <name> cogtainer build               # Build + push executor Docker image to ECR
 cogent <name> cogtainer status              # Check infrastructure status
 ```
@@ -107,7 +107,7 @@ cogent <name> dashboard deploy --docker
 
 **Full infrastructure change** (CDK constructs, IAM, ALB):
 ```bash
-cogent <name> cogtainer create --watch
+cogent <name> cogtainer create
 cogent <name> cogos image boot cogent-v1
 ```
 

--- a/src/cogtainer/cli.py
+++ b/src/cogtainer/cli.py
@@ -178,9 +178,8 @@ def status_cmd(ctx: click.Context):
 
 @cogtainer.command("create")
 @click.option("--profile", default=None, help=_PROFILE_HELP)
-@click.option("--watch", "-w", is_flag=True, help="Wait for stack to complete")
 @click.pass_context
-def create_cmd(ctx: click.Context, profile: str | None, watch: bool):
+def create_cmd(ctx: click.Context, profile: str | None):
     """Deploy a cogent's cogtainer infrastructure in the polis account."""
     import os
     import subprocess
@@ -230,9 +229,6 @@ def create_cmd(ctx: click.Context, profile: str | None, watch: bool):
         "--app", "python -m cogtainer.cdk.app",
         "--require-approval", "never",
     ]
-    if watch:
-        cmd.append("--watch")
-
     env = {**os.environ, "AWS_PROFILE": profile}
     deploy = subprocess.Popen(cmd, env=env)
     uploaded_assets = False


### PR DESCRIPTION
## Summary

- Remove the `--watch` CLI flag from `cogent <name> cogtainer create`
- Update all references in docs (`deploy.md`), `AGENTS.md`, and the `deploy.cogtainer` skill

CDK's `--watch` is a file-watching hot-reload mode that requires a `"watch"` key in `cdk.json` (which we don't configure). `cdk deploy` already waits for stack completion by default, so `--watch` was both misleading ("Wait for stack to complete") and broken.

## Test plan

- [ ] Run `uv run cogent dr.gamma cogtainer create --help` and confirm `--watch` is gone
- [ ] Run `uv run cogent dr.gamma cogtainer create` and confirm it still deploys and waits for completion

Co-Authored-By: Claude <noreply@anthropic.com>