### PR TITLE
fix dashboard 500s: cron event_type rename, traces RDS 1MB limit

### DIFF
--- a/src/cogos/db/local_repository.py
+++ b/src/cogos/db/local_repository.py
@@ -1074,6 +1074,7 @@ class LocalRepository:
         since: str | None = None,
         limit: int = 50,
         epoch: int | None = None,
+        slim: bool = False,
     ) -> list[Run]:
         self._maybe_reload()
         effective_epoch = self._reboot_epoch if epoch is None else epoch

--- a/src/cogos/db/repository.py
+++ b/src/cogos/db/repository.py
@@ -1335,6 +1335,12 @@ class Repository:
         row = self._first_row(response)
         return self._run_from_row(row) if row else None
 
+    _RUN_SLIM_COLUMNS = (
+        "id, epoch, process, message, conversation, status, tokens_in, tokens_out, "
+        "cost_usd, duration_ms, error, model_version, result, trace_id, parent_trace_id, "
+        "metadata, created_at, completed_at"
+    )
+
     def list_runs(
         self,
         *,
@@ -1344,6 +1350,7 @@ class Repository:
         since: str | None = None,
         limit: int = 50,
         epoch: int | None = None,
+        slim: bool = False,
     ) -> list[Run]:
         effective_epoch = self.reboot_epoch if epoch is None else epoch
         conditions = []
@@ -1366,8 +1373,9 @@ class Repository:
             conditions.append("created_at >= :since::timestamptz")
             params.append(self._param("since", since))
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        columns = self._RUN_SLIM_COLUMNS if slim else "*"
         response = self._execute(
-            f"SELECT * FROM cogos_run{where} ORDER BY created_at DESC LIMIT :limit",
+            f"SELECT {columns} FROM cogos_run{where} ORDER BY created_at DESC LIMIT :limit",
             params,
         )
         return [self._run_from_row(r) for r in self._rows_to_dicts(response)]

--- a/src/dashboard/routers/cron.py
+++ b/src/dashboard/routers/cron.py
@@ -22,7 +22,7 @@ def _cron_to_item(c: Cron) -> CronItem:
     return CronItem(
         id=str(c.id),
         cron_expression=c.expression,
-        channel_name=c.event_type,
+        channel_name=c.channel_name,
         enabled=c.enabled,
         metadata=c.payload or {},
         created_at=str(c.created_at) if c.created_at else None,
@@ -42,7 +42,7 @@ def create_cron(name: str, body: CronCreate) -> CronItem:
     repo = get_repo()
     cron = Cron(
         expression=body.cron_expression,
-        event_type=body.channel_name,
+        channel_name=body.channel_name,
         enabled=body.enabled,
         payload=body.metadata or {},
     )

--- a/src/dashboard/routers/traces.py
+++ b/src/dashboard/routers/traces.py
@@ -277,7 +277,7 @@ def list_message_traces(
     handlers = repo.list_handlers()
     messages = repo.list_channel_messages(limit=fetch_limit)
     deliveries = repo.list_deliveries(limit=max(fetch_limit * 2, 1000))
-    runs = repo.list_runs(limit=max(fetch_limit * 2, 1000))
+    runs = repo.list_runs(limit=max(fetch_limit * 2, 1000), slim=True)
 
     process_names = {process.id: process.name for process in processes}
     process_runners = {process.id: process.runner for process in processes}

--- a/tests/dashboard/test_routers_traces.py
+++ b/tests/dashboard/test_routers_traces.py
@@ -119,7 +119,7 @@ class _TraceRepoStub:
             deliveries = [delivery for delivery in deliveries if delivery.run == run_id]
         return deliveries[:limit]
 
-    def list_runs(self, *, process_id=None, limit: int = 50, epoch=None):
+    def list_runs(self, *, process_id=None, limit: int = 50, epoch=None, slim: bool = False):
         runs = [self.run]
         if process_id is not None:
             runs = [run for run in runs if run.process == process_id]


### PR DESCRIPTION
- Fix cron router accessing removed event_type field (renamed to channel_name)
- Fix message-traces 500 by adding slim=True to list_runs, excluding snapshot/scope_log columns that exceed RDS Data API 1MB limit

Co-Authored-By: Claude <noreply@anthropic.com>